### PR TITLE
Moved default java_download_dir under user home

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ java_install_dir: /opt/java
 java_home: "{{ java_install_dir }}/jdk{{ java_version }}"
 
 # Directory to store files downloaded for Java installation
-java_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
+java_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
 
 # SHA256 sum for the redistributable JDK package
 java_redis_sha256sum: 7cfbe0bc0391a4abe60b3e9eb2a541d2315b99b9cb3a24980e618a89229e04b7

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,4 @@ java_install_dir: /opt/java
 java_home: "{{ java_install_dir }}/jdk{{ java_version }}"
 
 # Directory to store files downloaded for Java installation
-java_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
+java_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"


### PR DESCRIPTION
Changed default for `java_download_dir` from `/tmp/ansible/data` to `~/.ansible/tmp/downloads`.

Enhancement: resolves #10