### PR TITLE
Added ansible_managed header to template files

### DIFF
--- a/templates/facts.j2
+++ b/templates/facts.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 [general]
 version={{ java_jdk_version }}
 home={{ java_home }}

--- a/templates/java.sh.j2
+++ b/templates/java.sh.j2
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+# {{ ansible_managed }}
+
 export JAVA_HOME="{{ java_home }}"
 export PATH="${PATH}:${JAVA_HOME}/bin"


### PR DESCRIPTION
This is useful to tell users that a file has been placed by Ansible and manual changes are likely to be overwritten.