### PR TITLE
Adopted yes|no convention for booleans

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,9 +49,9 @@
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
     dest: "{{ java_download_dir }}/{{ java_redis_filename }}"
     sha256sum: "{{ java_redis_sha256sum }}"
-    force: false
-    use_proxy: true
-    validate_certs: true
+    force: no
+    use_proxy: yes
+    validate_certs: yes
     mode: 'u=rw,go=r'
 
 - name: download JCE
@@ -60,9 +60,9 @@
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
     dest: "{{ java_download_dir }}/{{ java_jce_redis_filename }}"
     sha256sum: "{{ java_jce_redis_sha256sum }}"
-    force: false
-    use_proxy: true
-    validate_certs: true
+    force: no
+    use_proxy: yes
+    validate_certs: yes
     mode: 'u=rw,go=r'
 
 # Unpack installation


### PR DESCRIPTION
Ansible supports `true|false` and `yes|no` (with varying case) for boolean values; the Ansible documentation is wildly inconsistent on which it uses, so it's easy to end up with a mixture.

It's better to be consistent, so `yes|no` is now the convention for all Ansible roles written by GantSign.