### PR TITLE
Fixed default java_download_dir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ java_install_dir: '/opt/java'
 java_home: "{{ java_install_dir }}/jdk{{ java_version }}"
 
 # Directory to store files downloaded for Java installation
-java_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
+java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 
 # Timeout for JDK download response in seconds
 java_jdk_download_timeout_seconds: 600

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ java_install_dir: '/opt/java'
 java_home: "{{ java_install_dir }}/jdk{{ java_version }}"
 
 # Directory to store files downloaded for Java installation
-java_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
+java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 
 # Timeout for JDK download response in seconds
 java_jdk_download_timeout_seconds: 600


### PR DESCRIPTION
Ensure the `java_download_dir` defaults to the remote users home directory rather than the local user.