### PR TITLE
Switched to package module to install unzip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,19 +88,12 @@
     group: root
     mode: 'go-w'
 
-- name: install unzip (apt)
+- name: install unzip (apt, yum)
   become: yes
-  apt:
+  package:
     name: unzip
     state: present
-  when: ansible_pkg_mgr == 'apt'
-
-- name: install unzip (yum)
-  become: yes
-  yum:
-    name: unzip
-    state: present
-  when: ansible_pkg_mgr == 'yum'
+  when: ansible_pkg_mgr in ('apt', 'yum')
 
 - name: unzip JCE
   unarchive:


### PR DESCRIPTION
The `package` module can be used for both the `apt` and `yum` install of `unzip`.