### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ java_version: '8u112'
 java_install_dir: '/opt/java'
 
 # The root folder of this Java installation
-java_home: "{{ java_install_dir }}/jdk{{ java_version }}"
+java_home: '{{ java_install_dir }}/jdk{{ java_version }}'
 
 # Directory to store files downloaded for Java installation
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
@@ -123,7 +123,7 @@ different way the JDK was packaged for those releases.
 java_jce_redis_sha256sum: 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59'
 
 # Directory on remote mirror where JCE redistributable can be found
-java_jce_redis_mirror: "{{ java_mirror_base }}/jce/8"
+java_jce_redis_mirror: '{{ java_mirror_base }}/jce/8'
 
 # The JCE redistributable file name
 java_jce_redis_filename: 'jce_policy-8.zip'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ java_version: '8u112'
 java_install_dir: '/opt/java'
 
 # The root folder of this Java installation
-java_home: "{{ java_install_dir }}/jdk{{ java_version }}"
+java_home: '{{ java_install_dir }}/jdk{{ java_version }}'
 
 # Directory to store files downloaded for Java installation
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,15 +2,15 @@
 # Load version specific values
 - name: load JDK version vars
   with_first_found:
-    - "../vars/jdk-versions/{{ java_version }}.yml"
+    - '../vars/jdk-versions/{{ java_version }}.yml'
     - ../vars/jdk-versions/default.yml
-  include_vars: "{{ item }}"
+  include_vars: '{{ item }}'
 
 - name: load JCE version vars
   with_first_found:
-    - "../vars/jce-versions/{{ java_jce_version }}.yml"
+    - '../vars/jce-versions/{{ java_jce_version }}.yml'
     - ../vars/jce-versions/default.yml
-  include_vars: "{{ item }}"
+  include_vars: '{{ item }}'
 
 - name: assert version vars
   assert:
@@ -32,7 +32,7 @@
   file:
     state: directory
     mode: 'u=rwx,go=rx'
-    dest: "{{ java_download_dir }}"
+    dest: '{{ java_download_dir }}'
 
 # Ensure CA certificates installed (so we can download the JDK)
 - name: ensure ca-certificates installed (apt)
@@ -45,33 +45,33 @@
 # Download install files
 - name: download JDK
   get_url:
-    url: "{{ java_redis_mirror }}/{{ java_redis_filename }}"
+    url: '{{ java_redis_mirror }}/{{ java_redis_filename }}'
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
-    dest: "{{ java_download_dir }}/{{ java_redis_filename }}"
-    sha256sum: "{{ java_redis_sha256sum }}"
+    dest: '{{ java_download_dir }}/{{ java_redis_filename }}'
+    sha256sum: '{{ java_redis_sha256sum }}'
     force: no
     use_proxy: yes
     validate_certs: yes
-    timeout: "{{ java_jdk_download_timeout_seconds }}"
+    timeout: '{{ java_jdk_download_timeout_seconds }}'
     mode: 'u=rw,go=r'
 
 - name: download JCE
   get_url:
-    url: "{{ java_jce_redis_mirror }}/{{ java_jce_redis_filename }}"
+    url: '{{ java_jce_redis_mirror }}/{{ java_jce_redis_filename }}'
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
-    dest: "{{ java_download_dir }}/{{ java_jce_redis_filename }}"
-    sha256sum: "{{ java_jce_redis_sha256sum }}"
+    dest: '{{ java_download_dir }}/{{ java_jce_redis_filename }}'
+    sha256sum: '{{ java_jce_redis_sha256sum }}'
     force: no
     use_proxy: yes
     validate_certs: yes
-    timeout: "{{ java_jce_download_timeout_seconds }}"
+    timeout: '{{ java_jce_download_timeout_seconds }}'
     mode: 'u=rw,go=r'
 
 # Unpack installation
 - name: create Java home directory
   become: yes
   file:
-    path: "{{ java_home }}"
+    path: '{{ java_home }}'
     state: directory
     owner: root
     group: root
@@ -80,9 +80,9 @@
 - name: install JDK
   become: yes
   unarchive:
-    src: "{{ java_download_dir }}/{{ java_redis_filename }}"
-    dest: "{{ java_install_dir }}"
-    creates: "{{ java_home }}/bin/java"
+    src: '{{ java_download_dir }}/{{ java_redis_filename }}'
+    dest: '{{ java_install_dir }}'
+    creates: '{{ java_home }}/bin/java'
     copy: no
     owner: root
     group: root
@@ -97,17 +97,17 @@
 
 - name: unzip JCE
   unarchive:
-    src: "{{ java_download_dir }}/{{ java_jce_redis_filename }}"
-    dest: "{{ java_download_dir }}"
-    creates: "{{ java_download_dir }}/{{ java_jce_redis_folder }}/local_policy.jar"
+    src: '{{ java_download_dir }}/{{ java_jce_redis_filename }}'
+    dest: '{{ java_download_dir }}'
+    creates: '{{ java_download_dir }}/{{ java_jce_redis_folder }}/local_policy.jar'
     copy: no
 
 - name: install local_policy.jar
   become: yes
   copy:
-    src: "{{ java_download_dir }}/{{ java_jce_redis_folder }}/local_policy.jar"
+    src: '{{ java_download_dir }}/{{ java_jce_redis_folder }}/local_policy.jar'
     remote_src: yes
-    dest: "{{ java_home }}/jre/lib/security/local_policy.jar"
+    dest: '{{ java_home }}/jre/lib/security/local_policy.jar'
     owner: root
     group: root
     mode: 'u=rw,go=r'
@@ -115,9 +115,9 @@
 - name: install US_export_policy.jar
   become: yes
   copy:
-    src: "{{ java_download_dir }}/{{ java_jce_redis_folder }}/US_export_policy.jar"
+    src: '{{ java_download_dir }}/{{ java_jce_redis_folder }}/US_export_policy.jar'
     remote_src: yes
-    dest: "{{ java_home }}/jre/lib/security/US_export_policy.jar"
+    dest: '{{ java_home }}/jre/lib/security/US_export_policy.jar'
     owner: root
     group: root
     mode: 'u=rw,go=r'

--- a/vars/jce-versions/7.yml
+++ b/vars/jce-versions/7.yml
@@ -3,7 +3,7 @@
 java_jce_redis_sha256sum: '7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d'
 
 # Directory on remote mirror where JCE redistributable can be found
-java_jce_redis_mirror: "{{ java_mirror_base }}/jce/7"
+java_jce_redis_mirror: '{{ java_mirror_base }}/jce/7'
 
 # The JCE redistributable file name
 java_jce_redis_filename: UnlimitedJCEPolicyJDK7.zip

--- a/vars/jce-versions/8.yml
+++ b/vars/jce-versions/8.yml
@@ -3,7 +3,7 @@
 java_jce_redis_sha256sum: 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59'
 
 # Directory on remote mirror where JCE redistributable can be found
-java_jce_redis_mirror: "{{ java_mirror_base }}/jce/8"
+java_jce_redis_mirror: '{{ java_mirror_base }}/jce/8'
 
 # The JCE redistributable file name
 java_jce_redis_filename: 'jce_policy-8.zip'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,17 +3,17 @@
 java_jdk_version: "{{ java_version | regex_replace('^([0-9]+)u([0-9]+)$', '1.\\1.0_\\2') }}"
 
 # The root folder of this Java installation
-java_home: "{{ java_install_dir }}/jdk{{ java_jdk_version }}"
+java_home: '{{ java_install_dir }}/jdk{{ java_jdk_version }}'
 
 # Java JCE version number
 java_jce_version: "{{ java_version | regex_replace('^([0-9]+).*', '\\1') }}"
 
 # Where to download Oracle Java implementation from
 java_mirror_base: 'http://download.oracle.com/otn-pub/java'
-java_mirror: "{{ java_mirror_base }}/jdk"
+java_mirror: '{{ java_mirror_base }}/jdk'
 
 # File name for the JDK redistributable installation file
-java_redis_filename: "jdk-{{ java_version }}-linux-x64.tar.gz"
+java_redis_filename: 'jdk-{{ java_version }}-linux-x64.tar.gz'
 
 # Directory on remote mirror where java redistributable can be found
-java_redis_mirror: "{{ java_mirror }}/{{ java_version }}-b{{ java_version_build }}"
+java_redis_mirror: '{{ java_mirror }}/{{ java_version }}-b{{ java_version_build }}'


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.