### PR TITLE
Fixed download URLs when installing multiple JVM versions

### DIFF
--- a/vars/jdk-versions/7u79.yml
+++ b/vars/jdk-versions/7u79.yml
@@ -4,3 +4,6 @@ java_redis_sha256sum: '40d7cf35f424cbb2c951eca4659a6cfb6d743cf53048f8bc548cbe425
 
 # The build number for this JDK version
 java_version_build: 14
+
+# ID in JDK download URL
+java_jdk_download_id: ''

--- a/vars/jdk-versions/7u80.yml
+++ b/vars/jdk-versions/7u80.yml
@@ -4,3 +4,6 @@ java_redis_sha256sum: 'bad9a731639655118740bee119139c1ed019737ec802a630dd7ad7aab
 
 # The build number for this JDK version
 java_version_build: 15
+
+# ID in JDK download URL
+java_jdk_download_id: ''

--- a/vars/jdk-versions/8u101.yml
+++ b/vars/jdk-versions/8u101.yml
@@ -4,3 +4,6 @@ java_redis_sha256sum: '467f323ba38df2b87311a7818bcbf60fe0feb2139c455dfa0e08ba7ed
 
 # The build number for this JDK version
 java_version_build: 13
+
+# ID in JDK download URL
+java_jdk_download_id: ''

--- a/vars/jdk-versions/8u102.yml
+++ b/vars/jdk-versions/8u102.yml
@@ -4,3 +4,6 @@ java_redis_sha256sum: '7cfbe0bc0391a4abe60b3e9eb2a541d2315b99b9cb3a24980e618a892
 
 # The build number for this JDK version
 java_version_build: 14
+
+# ID in JDK download URL
+java_jdk_download_id: ''

--- a/vars/jdk-versions/8u111.yml
+++ b/vars/jdk-versions/8u111.yml
@@ -4,3 +4,6 @@ java_redis_sha256sum: '187eda2235f812ddb35c352b5f9aa6c5b184d611c2c9d0393afb8031d
 
 # The build number for this JDK version
 java_version_build: 14
+
+# ID in JDK download URL
+java_jdk_download_id: ''

--- a/vars/jdk-versions/8u112.yml
+++ b/vars/jdk-versions/8u112.yml
@@ -4,3 +4,6 @@ java_redis_sha256sum: '777bd7d5268408a5a94f5e366c2e43e720c6ce4fe8c59d9a71e2961e5
 
 # The build number for this JDK version
 java_version_build: 15
+
+# ID in JDK download URL
+java_jdk_download_id: ''


### PR DESCRIPTION
When installing multiple JVM versions `java_jdk_download_id` wasn't reset to empty string for versions where it wasn't used, this caused the download to fail due to an invalid URL.