### PR TITLE
Added fact group name for multiple JDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.an
 # variable.
 java_is_default_installation: yes
 
+# Name of the group of Ansible facts relating this Java installation.
+#
+# Override if you want use this role more than once to install multiple versions
+# of Java.
+#
+# e.g. java_fact_group_name: java_8
+# would change the Java home fact to:
+# ansible_local.java_8.general.home
+java_fact_group_name: java
+
 # Timeout for JDK download response in seconds
 java_jdk_download_timeout_seconds: 600
 
@@ -175,6 +185,21 @@ then additional configuration will be required - see
       java_version: '8u121'
 ```
 
+You can install the multiple versions of the Oracle JDK by using this role more
+than once:
+
+```yaml
+- hosts: servers
+  roles:
+    - role: ansible-role-java
+      java_version: '8u121'
+
+    - role: ansible-role-java
+      java_version: '7u80'
+      java_is_default_installation: no
+      java_fact_group_name: java_7
+```
+
 Role Facts
 ----------
 
@@ -187,6 +212,18 @@ This role exports the following Ansible facts for use by other roles:
 * `ansible_local.java.general.home`
 
     * e.g. `/opt/java/jdk1.8.0_102`
+
+Overriding `java_fact_group_name` will change the name of the fact e.g.:
+
+```yaml
+java_fact_group_name: java_8
+```
+
+Would change the name of the facts to:
+
+* `ansible_local.java_8.general.version`
+* `ansible_local.java_8.general.home`
+
 
 More Roles From GantSign
 ------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,16 @@ java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.an
 # variable.
 java_is_default_installation: yes
 
+# Name of the group of Ansible facts relating this Java installation.
+#
+# Override if you want use this role more than once to install multiple versions
+# of Java.
+#
+# e.g. java_fact_group_name: java_8
+# would change the Java home fact to:
+# ansible_local.java_8.general.home
+java_fact_group_name: java
+
 # Timeout for JDK download response in seconds
 java_jdk_download_timeout_seconds: 600
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,7 +152,7 @@
   become: yes
   template:
     src: facts.j2
-    dest: /etc/ansible/facts.d/java.fact
+    dest: '/etc/ansible/facts.d/{{ java_fact_group_name }}.fact'
     owner: root
     group: root
     mode: 'u=rw,go=r'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -20,11 +20,28 @@
       when: ansible_pkg_mgr == 'zypper'
 
   roles:
-    - ansible-role-java
+    - role: ansible-role-java
+
+    - role: ansible-role-java
+      java_version: 7u80
+      java_is_default_installation: no
+      java_fact_group_name: java_7
 
   post_tasks:
-    - name: verify java facts
+    - name: verify default java facts
       assert:
         that:
           - ansible_local.java.general.version is defined
           - ansible_local.java.general.home is defined
+
+    - name: verify java 7 facts
+      assert:
+        that:
+          - ansible_local.java_7.general.version is defined
+          - ansible_local.java_7.general.home is defined
+
+    - name: install find - required for tests (dnf)
+      dnf:
+        name: findutils
+        state: present
+      when: ansible_pkg_mgr == 'dnf'

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -15,11 +15,15 @@ def test_java_tools(Command, command):
     assert ' 1.8.0_' in cmd.stderr
 
 
-def test_java_installed(Command, File):
+@pytest.mark.parametrize('version_dir_pattern', [
+    'jdk1\\.7\\.0_[0-9]+$',
+    'jdk1\\.8\\.0_[0-9]+$'
+])
+def test_java_installed(Command, File, version_dir_pattern):
 
     java_home = Command.check_output('find %s | grep --color=never -E %s',
                                      '/opt/java/',
-                                     'jdk1\\.8\\.0_[0-9]+$')
+                                     version_dir_pattern)
 
     java_exe = File(java_home + '/bin/java')
 
@@ -30,8 +34,12 @@ def test_java_installed(Command, File):
     assert oct(java_exe.mode) == '0755'
 
 
-def test_facts_installed(File):
-    fact_file = File('/etc/ansible/facts.d/java.fact')
+@pytest.mark.parametrize('fact_group_name', [
+    'java',
+    'java_7'
+])
+def test_facts_installed(File, fact_group_name):
+    fact_file = File('/etc/ansible/facts.d/' + fact_group_name + '.fact')
 
     assert fact_file.exists
     assert fact_file.is_file


### PR DESCRIPTION
To avoid overwriting the fact file and give you access to the facts for multiple JDK versions.