### PR TITLE
Fixed comment for java_is_default_installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ java_home: '{{ java_install_dir }}/jdk{{ java_version }}'
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 
 # If this is the default installation, profile scripts will be written to set
-# the JAVA_HOME environment variable and add it to the PATH environment
-# variable.
+# the JAVA_HOME environment variable and add the bin directory to the PATH
+# environment variable.
 java_is_default_installation: yes
 
 # Name of the group of Ansible facts relating this Java installation.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,8 +12,8 @@ java_home: '{{ java_install_dir }}/jdk{{ java_version }}'
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 
 # If this is the default installation, profile scripts will be written to set
-# the JAVA_HOME environment variable and add it to the PATH environment
-# variable.
+# the JAVA_HOME environment variable and add the bin directory to the PATH
+# environment variable.
 java_is_default_installation: yes
 
 # Name of the group of Ansible facts relating this Java installation.


### PR DESCRIPTION
The comment for the `PATH` environment variable was inaccurate; it's actually the `bin` directory that is added to the path rather than `JAVA_HOME`.