### PR TITLE
Improved multi-version example

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ than once:
   roles:
     - role: ansible-role-java
       java_version: '8u121'
+      java_is_default_installation: yes
+      java_fact_group_name: java
 
     - role: ansible-role-java
       java_version: '7u80'


### PR DESCRIPTION
It's now order independent and explicit as to which is the default version and group name.