### PR TITLE
Link /usr/bin/java when java_is_default_installation is true

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,12 @@ java_install_dir: '/opt/java'
 # The root folder of this Java installation
 java_home: '{{ java_install_dir }}/jdk{{ java_version }}'
 
+# Name for link to default java install
+java_default_link: 'default'
+
+# The path to java default link
+java_default_link_path: '{{ java_install_dir }}/{{ java_default_link }}'
+
 # Directory to store files downloaded for Java installation
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -160,3 +160,42 @@
 - name: re-read facts
   setup:
     filter: ansible_local
+
+- block:
+
+    - name: link "{{ java_default_link_path }}"
+      file:
+        dest: "{{ java_default_link_path }}"
+        src: "{{ java_home }}"
+        state: link
+
+    - name: alternatives link for "java"
+      alternatives:
+        name: java
+        link: /usr/bin/java
+        path: "{{ java_default_link_path }}/bin/java"
+
+    - name: alternatives link for "javac"
+      alternatives:
+        name: javac
+        link: /usr/bin/javac
+        path: "{{ java_default_link_path }}/bin/javac"
+
+    - name: alternatives link for "jar"
+      alternatives:
+        name: jar
+        link: /usr/bin/jar
+        path: "{{ java_default_link_path }}/bin/jar"
+
+    - name: check if "java_sdk" target exists
+      stat: path=/usr/lib/jvm/java
+      register: filecheck
+
+    - name: alternatives link for "java_sdk"
+      alternatives:
+        name: java_sdk
+        link: /usr/lib/jvm/java
+        path: "{{ java_default_link_path }}"
+      when: filecheck and filecheck.stat.exists
+
+  when: java_is_default_installation


### PR DESCRIPTION
Ran into an issue using this role to install java where the default installation does not get set up in /usr/bin/java and some applications may not pick it up properly from the path. Easiest solution seems to be to link /usr/bin/java with the newly installed java, when java_is_default_installation is true.