### PR TITLE
Added support for local archive dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,15 @@ java_install_dir: '/opt/java'
 # The root folder of this Java installation
 java_home: '{{ java_install_dir }}/jdk{{ java_version }}'
 
-# Directory to store files downloaded for Java installation
+# Directory to store files downloaded for Java installation on the remote box
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
+
+# Location Java installations packages can be found on the local box
+# local packages will be uses in preference to downloading new packages.
+java_local_archive_dir: '{{ playbook_dir }}/files'
+
+# Wether to use installation packages in the local archive (if available)
+java_use_local_archive: yes
 
 # If this is the default installation, profile scripts will be written to set
 # the JAVA_HOME environment variable and add the bin directory to the PATH
@@ -111,6 +118,16 @@ configuration (for other versions follow the Advanced Configuration
 instructions):
 
 * 8u131
+
+**Archived versions** As of 23 May 2017 all the archived Java versions (i.e.
+everything but the latest release) have been moved from the Oracle public
+download area to behind the Oracle Technology Network login.
+
+This Ansible role is no longer able to download archived versions of Java from
+Oracle; to workaround this limitation you should manually download the
+`jdk-VERSION-linux-x64.tar.gz` file from Oracle and put it into
+`java_local_archive_dir`.
+
 * 8u121
 * 8u112
 * 8u111

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,15 @@ java_install_dir: '/opt/java'
 # The root folder of this Java installation
 java_home: '{{ java_install_dir }}/jdk{{ java_version }}'
 
-# Directory to store files downloaded for Java installation
+# Directory to store files downloaded for Java installation on the remote box
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
+
+# Location Java installations packages can be found on the local box
+# local packages will be uses in preference to downloading new packages.
+java_local_archive_dir: '{{ playbook_dir }}/files'
+
+# Wether to use installation packages in the local archive (if available)
+java_use_local_archive: yes
 
 # If this is the default installation, profile scripts will be written to set
 # the JAVA_HOME environment variable and add the bin directory to the PATH

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,6 +1,11 @@
 ---
 ansible:
   playbook: tests/test.yml
+  group_vars:
+    online:
+      java_use_local_archive: no
+    offline:
+      java_use_local_archive: yes
   extra_vars:
     java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
@@ -15,29 +20,45 @@ docker:
   - name: ansible-role-java-debian-wheezy
     image: debian
     image_version: '7'
+    ansible_groups:
+    - online
   - name: ansible-role-java-debian-jessie
     image: debian
     image_version: '8'
+    ansible_groups:
+    - offline
   - name: ansible-role-java-ubuntu-trusty
     image: ubuntu
     image_version: '14.04'
+    ansible_groups:
+    - online
   - name: ansible-role-java-ubuntu-xenial
     image: ubuntu
     image_version: '16.04'
+    ansible_groups:
+    - offline
   - name: ansible-role-java-centos-6
     image: centos
     image_version: '6'
+    ansible_groups:
+    - online
   - name: ansible-role-java-centos-7
     image: centos
     image_version: '7'
+    ansible_groups:
+    - offline
   - name: ansible-role-maven-fedora-25
     image: fedora
     image_version: '25'
     command: /bin/bash
+    ansible_groups:
+    - online
   - name: ansible-role-maven-opensuse-leap
     image: opensuse
     image_version: '42.2'
     command: /bin/bash
+    ansible_groups:
+    - online
 
 verifier:
   name: testinfra

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,34 @@
     mode: 'u=rwx,go=rx'
     dest: '{{ java_download_dir }}'
 
+- name: check for JDK on local box
+  local_action: stat path='{{ java_local_archive_dir }}/{{ java_redis_filename }}'
+  register: local_JDK_file
+  ignore_errors: yes
+  when: java_use_local_archive
+
+- name: copy JDK from local box
+  become: yes
+  copy:
+    src: '{{ java_local_archive_dir }}/{{ java_redis_filename }}'
+    dest: '{{ java_download_dir }}/{{ java_redis_filename }}'
+    mode: 'u=rw,go=r'
+  when: java_use_local_archive and local_JDK_file.stat.exists
+
+- name: check for JDK on remote box
+  stat:
+    path: '{{ java_download_dir }}/{{ java_redis_filename }}'
+    checksum_algorithm: sha256
+  register: remote_JDK_file
+  ignore_errors: yes
+
+- name: assert existing JDK matches checksum
+  assert:
+    that:
+      - remote_JDK_file.stat.checksum == java_redis_sha256sum
+    msg: 'Checksum failed: {{ remote_JDK_file.stat.checksum }} != {{ java_redis_sha256sum }}'
+  when: remote_JDK_file.stat.exists
+
 # Ensure CA certificates installed (so we can download the JDK)
 - name: ensure ca-certificates installed (apt)
   become: yes
@@ -64,6 +92,35 @@
     validate_certs: yes
     timeout: '{{ java_jdk_download_timeout_seconds }}'
     mode: 'u=rw,go=r'
+  when: not remote_JDK_file.stat.exists
+
+- name: check for JCE on local box
+  local_action: stat path='{{ java_local_archive_dir }}/{{ java_jce_redis_filename }}'
+  register: local_JCE_file
+  ignore_errors: yes
+  when: java_use_local_archive
+
+- name: copy JCE from local box
+  become: yes
+  copy:
+    src: '{{ java_local_archive_dir }}/{{ java_jce_redis_filename }}'
+    dest: '{{ java_download_dir }}/{{ java_jce_redis_filename }}'
+    mode: 'u=rw,go=r'
+  when: java_use_local_archive and local_JCE_file.stat.exists
+
+- name: check for JCE on remote box
+  stat:
+    path: '{{ java_download_dir }}/{{ java_jce_redis_filename }}'
+    checksum_algorithm: sha256
+  register: remote_JCE_file
+  ignore_errors: yes
+
+- name: assert existing JCE matches checksum
+  assert:
+    that:
+      - remote_JCE_file.stat.checksum == java_jce_redis_sha256sum
+    msg: 'Checksum failed: {{ remote_JCE_file.stat.checksum }} != {{ java_jce_redis_sha256sum }}'
+  when: remote_JCE_file.stat.exists
 
 - name: download JCE
   get_url:
@@ -76,6 +133,7 @@
     validate_certs: yes
     timeout: '{{ java_jce_download_timeout_seconds }}'
     mode: 'u=rw,go=r'
+  when: not remote_JCE_file.stat.exists
 
 # Unpack installation
 - name: create Java home directory

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -19,26 +19,42 @@
       changed_when: no
       when: ansible_pkg_mgr == 'zypper'
 
+    - name: create local archive directory
+      local_action: file state=directory mode='u=rwx,go=rx' dest='{{ java_local_archive_dir }}'
+
+    - name: download JDK for offline install
+      local_action: >
+        get_url
+        url='http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz'
+        headers='Cookie:oraclelicense=accept-securebackup-cookie'
+        dest='{{ java_local_archive_dir }}/jdk-8u131-linux-x64.tar.gz'
+        force=no
+        use_proxy=yes
+        validate_certs=yes
+        timeout='{{ java_jdk_download_timeout_seconds }}'
+        mode='u=rw,go=r'
+
+    - name: download JCE for offline install
+      local_action: >
+        get_url
+        url='http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
+        headers='Cookie:oraclelicense=accept-securebackup-cookie'
+        dest='{{ java_local_archive_dir }}/jce_policy-8.zip'
+        force=no
+        use_proxy=yes
+        validate_certs=yes
+        timeout='{{ java_jdk_download_timeout_seconds }}'
+        mode='u=rw,go=r'
+
   roles:
     - role: ansible-role-java
 
-    - role: ansible-role-java
-      java_version: 7u80
-      java_is_default_installation: no
-      java_fact_group_name: java_7
-
   post_tasks:
-    - name: verify default java facts
+    - name: verify java facts
       assert:
         that:
           - ansible_local.java.general.version is defined
           - ansible_local.java.general.home is defined
-
-    - name: verify java 7 facts
-      assert:
-        that:
-          - ansible_local.java_7.general.version is defined
-          - ansible_local.java_7.general.home is defined
 
     - name: install find - required for tests (dnf)
       dnf:

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -16,7 +16,6 @@ def test_java_tools(Command, command):
 
 
 @pytest.mark.parametrize('version_dir_pattern', [
-    'jdk1\\.7\\.0_[0-9]+$',
     'jdk1\\.8\\.0_[0-9]+$'
 ])
 def test_java_installed(Command, File, version_dir_pattern):
@@ -35,8 +34,7 @@ def test_java_installed(Command, File, version_dir_pattern):
 
 
 @pytest.mark.parametrize('fact_group_name', [
-    'java',
-    'java_7'
+    'java'
 ])
 def test_facts_installed(File, fact_group_name):
     fact_file = File('/etc/ansible/facts.d/' + fact_group_name + '.fact')


### PR DESCRIPTION
To workaround Oracle moving their archives behind OTN login, this role now support using local installation packages to avoid the need for this role to download them.