### PR TITLE
Moved Java bin to the start of the PATH

### DIFF
--- a/templates/java.sh.j2
+++ b/templates/java.sh.j2
@@ -3,4 +3,4 @@
 # {{ ansible_managed }}
 
 export JAVA_HOME="{{ java_home }}"
-export PATH="${PATH}:${JAVA_HOME}/bin"
+export PATH="${JAVA_HOME}/bin:${PATH}"


### PR DESCRIPTION
`$JAVA_HOME/bin` will now be added to the start of the PATH so it will take precedence over any versions installed using the package manager.