### PR TITLE
Use Travis CI build matrix for OS distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,40 @@
 language: python
 python: '2.7'
 
-# Spin off separate builds for each of the following versions of Ansible
-env:
-  - ANSIBLE_VERSION=2.0.2
-  - ANSIBLE_VERSION=2.3.0
+matrix:
+  include:
+    - env:
+        - MOLECULE_SCENARIO=ubuntu-trusty-online
+        - ANSIBLE_VERSION=2.2.0
+        - DOCKER_LIB=docker-py
+    - env:
+        - MOLECULE_SCENARIO=ubuntu-xenial-offline
+        - ANSIBLE_VERSION=2.3.0
+        - DOCKER_LIB=docker
+    - env:
+        - MOLECULE_SCENARIO=debian-wheezy-online
+        - ANSIBLE_VERSION=2.2.0
+        - DOCKER_LIB=docker-py
+    - env:
+        - MOLECULE_SCENARIO=debian-jessie-offline
+        - ANSIBLE_VERSION=2.3.0
+        - DOCKER_LIB=docker
+    - env:
+        - MOLECULE_SCENARIO=centos-6-online
+        - ANSIBLE_VERSION=2.2.0
+        - DOCKER_LIB=docker-py
+    - env:
+        - MOLECULE_SCENARIO=centos-7-offline
+        - ANSIBLE_VERSION=2.3.0
+        - DOCKER_LIB=docker
+    # - env:
+    #     - MOLECULE_SCENARIO=fedora-25-online
+    #     - ANSIBLE_VERSION=2.3.0
+    #     - DOCKER_LIB=docker
+    # - env:
+    #     - MOLECULE_SCENARIO=opensuse-leap-online
+    #     - ANSIBLE_VERSION=2.3.0
+    #     - DOCKER_LIB=docker
 
 # Require the standard build environment
 sudo: required
@@ -30,7 +60,7 @@ install:
   - pip install "ansible~=$ANSIBLE_VERSION"
 
   # Install Python API for Docker (required by Molecule Docker driver)
-  - pip install docker
+  - pip install $DOCKER_LIB
 
   # Install Molecule
   - pip install 'molecule==2.0.0.rc12'
@@ -42,11 +72,11 @@ install:
   - molecule --version
 
   # Build the Docker images
-  - molecule create
-  - molecule destroy
+  - molecule --debug create --scenario-name=$MOLECULE_SCENARIO
+  - molecule destroy --scenario-name=$MOLECULE_SCENARIO
 
 script:
-  - molecule test
+  - molecule test --scenario-name=$MOLECULE_SCENARIO
 
 branches:
   only:

--- a/molecule/ansible-role-java-centos-6-online/Dockerfile.j2
+++ b/molecule/ansible-role-java-centos-6-online/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/ansible-role-java-centos-6-online/INSTALL.rst
+++ b/molecule/ansible-role-java-centos-6-online/INSTALL.rst
@@ -1,0 +1,46 @@
+*******
+Install
+*******
+
+This set of playbooks have specific dependencies on Ansible due to the modules
+being used.
+
+Requirements
+============
+
+* Ansible 2.2
+* Docker Engine
+* docker-py
+
+Install OS dependencies on CentOS 7
+
+.. code-block:: bash
+
+  $ sudo yum install -y epel-release
+  $ sudo yum install -y gcc python-pip python-devel openssl-devel
+  # If installing Molecule from source.
+  $ sudo yum install libffi-devel git
+
+Install OS dependencies on Ubuntu 16.x
+
+.. code-block:: bash
+
+  $ sudo apt-get update
+  $ sudo apt-get install -y python-pip libssl-dev docker-engine
+  # If installing Molecule from source.
+  $ sudo apt-get install -y libffi-dev git
+
+Install OS dependencies on Mac OS
+
+.. code-block:: bash
+
+  $ brew install python
+  $ brew install git
+
+Install using pip:
+
+.. code-block:: bash
+
+  $ sudo pip install ansible
+  $ sudo pip install docker-py
+  $ sudo pip install molecule --pre

--- a/molecule/ansible-role-java-centos-6-online/molecule.yml
+++ b/molecule/ansible-role-java-centos-6-online/molecule.yml
@@ -1,6 +1,25 @@
 ---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-centos-6
+    image: centos:6
+    groups:
+      - online
+
 provisioner:
   name: ansible
+  playbooks:
+    setup: ../default/create.yml
+    teardown: ../default/destroy.yml
+    converge: ../default/playbook.yml
   inventory:
     group_vars:
       online:
@@ -13,25 +32,11 @@ provisioner:
   lint:
     name: ansible-lint
 
-dependency:
-  name: galaxy
-
-driver:
-  name: docker
-
-lint:
-  name: yamllint
-
-platforms:
-  - name: ansible-role-java-ubuntu-xenial
-    image: ubuntu:16.04
-    groups:
-      - offline
-
 scenario:
-  name: default
+  name: centos-6-online
 
 verifier:
   name: testinfra
+  directory: ../default/tests/
   lint:
     name: flake8

--- a/molecule/ansible-role-java-centos-7-offline/Dockerfile.j2
+++ b/molecule/ansible-role-java-centos-7-offline/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/ansible-role-java-centos-7-offline/INSTALL.rst
+++ b/molecule/ansible-role-java-centos-7-offline/INSTALL.rst
@@ -1,0 +1,46 @@
+*******
+Install
+*******
+
+This set of playbooks have specific dependencies on Ansible due to the modules
+being used.
+
+Requirements
+============
+
+* Ansible 2.2
+* Docker Engine
+* docker-py
+
+Install OS dependencies on CentOS 7
+
+.. code-block:: bash
+
+  $ sudo yum install -y epel-release
+  $ sudo yum install -y gcc python-pip python-devel openssl-devel
+  # If installing Molecule from source.
+  $ sudo yum install libffi-devel git
+
+Install OS dependencies on Ubuntu 16.x
+
+.. code-block:: bash
+
+  $ sudo apt-get update
+  $ sudo apt-get install -y python-pip libssl-dev docker-engine
+  # If installing Molecule from source.
+  $ sudo apt-get install -y libffi-dev git
+
+Install OS dependencies on Mac OS
+
+.. code-block:: bash
+
+  $ brew install python
+  $ brew install git
+
+Install using pip:
+
+.. code-block:: bash
+
+  $ sudo pip install ansible
+  $ sudo pip install docker-py
+  $ sudo pip install molecule --pre

--- a/molecule/ansible-role-java-centos-7-offline/molecule.yml
+++ b/molecule/ansible-role-java-centos-7-offline/molecule.yml
@@ -1,6 +1,25 @@
 ---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-centos-7
+    image: centos:7
+    groups:
+      - offline
+
 provisioner:
   name: ansible
+  playbooks:
+    setup: ../default/create.yml
+    teardown: ../default/destroy.yml
+    converge: ../default/playbook.yml
   inventory:
     group_vars:
       online:
@@ -13,25 +32,11 @@ provisioner:
   lint:
     name: ansible-lint
 
-dependency:
-  name: galaxy
-
-driver:
-  name: docker
-
-lint:
-  name: yamllint
-
-platforms:
-  - name: ansible-role-java-ubuntu-xenial
-    image: ubuntu:16.04
-    groups:
-      - offline
-
 scenario:
-  name: default
+  name: centos-7-offline
 
 verifier:
   name: testinfra
+  directory: ../default/tests/
   lint:
     name: flake8

--- a/molecule/ansible-role-java-fedora-25-online/Dockerfile.j2
+++ b/molecule/ansible-role-java-fedora-25-online/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/ansible-role-java-fedora-25-online/INSTALL.rst
+++ b/molecule/ansible-role-java-fedora-25-online/INSTALL.rst
@@ -1,0 +1,46 @@
+*******
+Install
+*******
+
+This set of playbooks have specific dependencies on Ansible due to the modules
+being used.
+
+Requirements
+============
+
+* Ansible 2.2
+* Docker Engine
+* docker-py
+
+Install OS dependencies on CentOS 7
+
+.. code-block:: bash
+
+  $ sudo yum install -y epel-release
+  $ sudo yum install -y gcc python-pip python-devel openssl-devel
+  # If installing Molecule from source.
+  $ sudo yum install libffi-devel git
+
+Install OS dependencies on Ubuntu 16.x
+
+.. code-block:: bash
+
+  $ sudo apt-get update
+  $ sudo apt-get install -y python-pip libssl-dev docker-engine
+  # If installing Molecule from source.
+  $ sudo apt-get install -y libffi-dev git
+
+Install OS dependencies on Mac OS
+
+.. code-block:: bash
+
+  $ brew install python
+  $ brew install git
+
+Install using pip:
+
+.. code-block:: bash
+
+  $ sudo pip install ansible
+  $ sudo pip install docker-py
+  $ sudo pip install molecule --pre

--- a/molecule/ansible-role-java-fedora-25-online/molecule.yml
+++ b/molecule/ansible-role-java-fedora-25-online/molecule.yml
@@ -1,6 +1,26 @@
 ---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-fedora-25
+    image: fedora:25
+    command: /bin/bash
+    groups:
+      - online
+
 provisioner:
   name: ansible
+  playbooks:
+    setup: ../default/create.yml
+    teardown: ../default/destroy.yml
+    converge: ../default/playbook.yml
   inventory:
     group_vars:
       online:
@@ -13,25 +33,11 @@ provisioner:
   lint:
     name: ansible-lint
 
-dependency:
-  name: galaxy
-
-driver:
-  name: docker
-
-lint:
-  name: yamllint
-
-platforms:
-  - name: ansible-role-java-ubuntu-xenial
-    image: ubuntu:16.04
-    groups:
-      - offline
-
 scenario:
-  name: default
+  name: fedora-25-online
 
 verifier:
   name: testinfra
+  directory: ../default/tests/
   lint:
     name: flake8

--- a/molecule/ansible-role-java-opensuse-leap-online/Dockerfile.j2
+++ b/molecule/ansible-role-java-opensuse-leap-online/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/ansible-role-java-opensuse-leap-online/INSTALL.rst
+++ b/molecule/ansible-role-java-opensuse-leap-online/INSTALL.rst
@@ -1,0 +1,46 @@
+*******
+Install
+*******
+
+This set of playbooks have specific dependencies on Ansible due to the modules
+being used.
+
+Requirements
+============
+
+* Ansible 2.2
+* Docker Engine
+* docker-py
+
+Install OS dependencies on CentOS 7
+
+.. code-block:: bash
+
+  $ sudo yum install -y epel-release
+  $ sudo yum install -y gcc python-pip python-devel openssl-devel
+  # If installing Molecule from source.
+  $ sudo yum install libffi-devel git
+
+Install OS dependencies on Ubuntu 16.x
+
+.. code-block:: bash
+
+  $ sudo apt-get update
+  $ sudo apt-get install -y python-pip libssl-dev docker-engine
+  # If installing Molecule from source.
+  $ sudo apt-get install -y libffi-dev git
+
+Install OS dependencies on Mac OS
+
+.. code-block:: bash
+
+  $ brew install python
+  $ brew install git
+
+Install using pip:
+
+.. code-block:: bash
+
+  $ sudo pip install ansible
+  $ sudo pip install docker-py
+  $ sudo pip install molecule --pre

--- a/molecule/ansible-role-java-opensuse-leap-online/molecule.yml
+++ b/molecule/ansible-role-java-opensuse-leap-online/molecule.yml
@@ -1,6 +1,26 @@
 ---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-opensuse-leap
+    image: opensuse:42.2
+    command: /bin/bash
+    groups:
+      - online
+
 provisioner:
   name: ansible
+  playbooks:
+    setup: ../default/create.yml
+    teardown: ../default/destroy.yml
+    converge: ../default/playbook.yml
   inventory:
     group_vars:
       online:
@@ -13,25 +33,11 @@ provisioner:
   lint:
     name: ansible-lint
 
-dependency:
-  name: galaxy
-
-driver:
-  name: docker
-
-lint:
-  name: yamllint
-
-platforms:
-  - name: ansible-role-java-ubuntu-xenial
-    image: ubuntu:16.04
-    groups:
-      - offline
-
 scenario:
-  name: default
+  name: opensuse-leap-online
 
 verifier:
   name: testinfra
+  directory: ../default/tests/
   lint:
     name: flake8

--- a/molecule/debian-jessie-offline/Dockerfile.j2
+++ b/molecule/debian-jessie-offline/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/debian-jessie-offline/INSTALL.rst
+++ b/molecule/debian-jessie-offline/INSTALL.rst
@@ -1,0 +1,46 @@
+*******
+Install
+*******
+
+This set of playbooks have specific dependencies on Ansible due to the modules
+being used.
+
+Requirements
+============
+
+* Ansible 2.2
+* Docker Engine
+* docker-py
+
+Install OS dependencies on CentOS 7
+
+.. code-block:: bash
+
+  $ sudo yum install -y epel-release
+  $ sudo yum install -y gcc python-pip python-devel openssl-devel
+  # If installing Molecule from source.
+  $ sudo yum install libffi-devel git
+
+Install OS dependencies on Ubuntu 16.x
+
+.. code-block:: bash
+
+  $ sudo apt-get update
+  $ sudo apt-get install -y python-pip libssl-dev docker-engine
+  # If installing Molecule from source.
+  $ sudo apt-get install -y libffi-dev git
+
+Install OS dependencies on Mac OS
+
+.. code-block:: bash
+
+  $ brew install python
+  $ brew install git
+
+Install using pip:
+
+.. code-block:: bash
+
+  $ sudo pip install ansible
+  $ sudo pip install docker-py
+  $ sudo pip install molecule --pre

--- a/molecule/debian-jessie-offline/molecule.yml
+++ b/molecule/debian-jessie-offline/molecule.yml
@@ -1,6 +1,25 @@
 ---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-debian-jessie
+    image: debian:8
+    groups:
+      - offline
+
 provisioner:
   name: ansible
+  playbooks:
+    setup: ../default/create.yml
+    teardown: ../default/destroy.yml
+    converge: ../default/playbook.yml
   inventory:
     group_vars:
       online:
@@ -13,25 +32,11 @@ provisioner:
   lint:
     name: ansible-lint
 
-dependency:
-  name: galaxy
-
-driver:
-  name: docker
-
-lint:
-  name: yamllint
-
-platforms:
-  - name: ansible-role-java-ubuntu-xenial
-    image: ubuntu:16.04
-    groups:
-      - offline
-
 scenario:
-  name: default
+  name: debian-jessie-offline
 
 verifier:
   name: testinfra
+  directory: ../default/tests/
   lint:
     name: flake8

--- a/molecule/debian-wheezy-online/Dockerfile.j2
+++ b/molecule/debian-wheezy-online/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/debian-wheezy-online/INSTALL.rst
+++ b/molecule/debian-wheezy-online/INSTALL.rst
@@ -1,0 +1,46 @@
+*******
+Install
+*******
+
+This set of playbooks have specific dependencies on Ansible due to the modules
+being used.
+
+Requirements
+============
+
+* Ansible 2.2
+* Docker Engine
+* docker-py
+
+Install OS dependencies on CentOS 7
+
+.. code-block:: bash
+
+  $ sudo yum install -y epel-release
+  $ sudo yum install -y gcc python-pip python-devel openssl-devel
+  # If installing Molecule from source.
+  $ sudo yum install libffi-devel git
+
+Install OS dependencies on Ubuntu 16.x
+
+.. code-block:: bash
+
+  $ sudo apt-get update
+  $ sudo apt-get install -y python-pip libssl-dev docker-engine
+  # If installing Molecule from source.
+  $ sudo apt-get install -y libffi-dev git
+
+Install OS dependencies on Mac OS
+
+.. code-block:: bash
+
+  $ brew install python
+  $ brew install git
+
+Install using pip:
+
+.. code-block:: bash
+
+  $ sudo pip install ansible
+  $ sudo pip install docker-py
+  $ sudo pip install molecule --pre

--- a/molecule/debian-wheezy-online/molecule.yml
+++ b/molecule/debian-wheezy-online/molecule.yml
@@ -1,6 +1,25 @@
 ---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-debian-wheezy
+    image: debian:7
+    groups:
+      - online
+
 provisioner:
   name: ansible
+  playbooks:
+    setup: ../default/create.yml
+    teardown: ../default/destroy.yml
+    converge: ../default/playbook.yml
   inventory:
     group_vars:
       online:
@@ -13,25 +32,11 @@ provisioner:
   lint:
     name: ansible-lint
 
-dependency:
-  name: galaxy
-
-driver:
-  name: docker
-
-lint:
-  name: yamllint
-
-platforms:
-  - name: ansible-role-java-ubuntu-xenial
-    image: ubuntu:16.04
-    groups:
-      - offline
-
 scenario:
-  name: default
+  name: debian-wheezy-online
 
 verifier:
   name: testinfra
+  directory: ../default/tests/
   lint:
     name: flake8

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -21,6 +21,7 @@
 
     - name: create local archive directory
       local_action: file state=directory mode='u=rwx,go=rx' dest='{{ java_local_archive_dir }}'
+      when: java_use_local_archive
 
     - name: download JDK for offline install
       local_action: >
@@ -33,6 +34,7 @@
         validate_certs=yes
         timeout='{{ java_jdk_download_timeout_seconds }}'
         mode='u=rw,go=r'
+      when: java_use_local_archive
 
     - name: download JCE for offline install
       local_action: >
@@ -45,6 +47,7 @@
         validate_certs=yes
         timeout='{{ java_jdk_download_timeout_seconds }}'
         mode='u=rw,go=r'
+      when: java_use_local_archive
 
   roles:
     - role: ansible-role-java

--- a/molecule/ubuntu-trusty-online/Dockerfile.j2
+++ b/molecule/ubuntu-trusty-online/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/ubuntu-trusty-online/INSTALL.rst
+++ b/molecule/ubuntu-trusty-online/INSTALL.rst
@@ -1,0 +1,46 @@
+*******
+Install
+*******
+
+This set of playbooks have specific dependencies on Ansible due to the modules
+being used.
+
+Requirements
+============
+
+* Ansible 2.2
+* Docker Engine
+* docker-py
+
+Install OS dependencies on CentOS 7
+
+.. code-block:: bash
+
+  $ sudo yum install -y epel-release
+  $ sudo yum install -y gcc python-pip python-devel openssl-devel
+  # If installing Molecule from source.
+  $ sudo yum install libffi-devel git
+
+Install OS dependencies on Ubuntu 16.x
+
+.. code-block:: bash
+
+  $ sudo apt-get update
+  $ sudo apt-get install -y python-pip libssl-dev docker-engine
+  # If installing Molecule from source.
+  $ sudo apt-get install -y libffi-dev git
+
+Install OS dependencies on Mac OS
+
+.. code-block:: bash
+
+  $ brew install python
+  $ brew install git
+
+Install using pip:
+
+.. code-block:: bash
+
+  $ sudo pip install ansible
+  $ sudo pip install docker-py
+  $ sudo pip install molecule --pre

--- a/molecule/ubuntu-trusty-online/molecule.yml
+++ b/molecule/ubuntu-trusty-online/molecule.yml
@@ -1,6 +1,25 @@
 ---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-ubuntu-trusty
+    image: ubuntu:14.04
+    groups:
+      - online
+
 provisioner:
   name: ansible
+  playbooks:
+    setup: ../default/create.yml
+    teardown: ../default/destroy.yml
+    converge: ../default/playbook.yml
   inventory:
     group_vars:
       online:
@@ -13,25 +32,11 @@ provisioner:
   lint:
     name: ansible-lint
 
-dependency:
-  name: galaxy
-
-driver:
-  name: docker
-
-lint:
-  name: yamllint
-
-platforms:
-  - name: ansible-role-java-ubuntu-xenial
-    image: ubuntu:16.04
-    groups:
-      - offline
-
 scenario:
-  name: default
+  name: ubuntu-trusty-online
 
 verifier:
   name: testinfra
+  directory: ../default/tests/
   lint:
     name: flake8

--- a/molecule/ubuntu-xenial-offline/Dockerfile.j2
+++ b/molecule/ubuntu-xenial-offline/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v dnf) ]; then dnf makecache fast && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; fi

--- a/molecule/ubuntu-xenial-offline/INSTALL.rst
+++ b/molecule/ubuntu-xenial-offline/INSTALL.rst
@@ -1,0 +1,46 @@
+*******
+Install
+*******
+
+This set of playbooks have specific dependencies on Ansible due to the modules
+being used.
+
+Requirements
+============
+
+* Ansible 2.2
+* Docker Engine
+* docker-py
+
+Install OS dependencies on CentOS 7
+
+.. code-block:: bash
+
+  $ sudo yum install -y epel-release
+  $ sudo yum install -y gcc python-pip python-devel openssl-devel
+  # If installing Molecule from source.
+  $ sudo yum install libffi-devel git
+
+Install OS dependencies on Ubuntu 16.x
+
+.. code-block:: bash
+
+  $ sudo apt-get update
+  $ sudo apt-get install -y python-pip libssl-dev docker-engine
+  # If installing Molecule from source.
+  $ sudo apt-get install -y libffi-dev git
+
+Install OS dependencies on Mac OS
+
+.. code-block:: bash
+
+  $ brew install python
+  $ brew install git
+
+Install using pip:
+
+.. code-block:: bash
+
+  $ sudo pip install ansible
+  $ sudo pip install docker-py
+  $ sudo pip install molecule --pre

--- a/molecule/ubuntu-xenial-offline/molecule.yml
+++ b/molecule/ubuntu-xenial-offline/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-ubuntu-xenial
+    image: ubuntu:16.04
+    groups:
+      - offline
+
+provisioner:
+  name: ansible
+  playbooks:
+    setup: ../default/create.yml
+    teardown: ../default/destroy.yml
+    converge: ../default/playbook.yml
+  inventory:
+    group_vars:
+      online:
+        java_use_local_archive: no
+      offline:
+        java_use_local_archive: yes
+  options:
+    extra-vars:
+      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
+  lint:
+    name: ansible-lint
+
+scenario:
+  name: ubuntu-xenial-offline
+
+verifier:
+  name: testinfra
+  directory: ../default/tests/
+  lint:
+    name: flake8


### PR DESCRIPTION
Leverage Molecule 2.0 scenarios to create a separate Travis CI build per OS distribution.

This should allow the build matrix to be reduced, minimize build failures, and make it easier to fix failed builds.