### PR TITLE
Documentation fix for java_home

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ java_version: '8u144'
 # Base installation directory for any Java distribution
 java_install_dir: '/opt/java'
 
-# The root folder of this Java installation
-java_home: '{{ java_install_dir }}/jdk{{ java_full_version }}'
-
 # Directory to store files downloaded for Java installation on the remote box
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,9 +7,6 @@ java_version: '8u144'
 # Base installation directory for any Java distribution
 java_install_dir: '/opt/java'
 
-# The root folder of this Java installation
-java_home: '{{ java_install_dir }}/jdk{{ java_full_version }}'
-
 # Directory to store files downloaded for Java installation on the remote box
 java_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 


### PR DESCRIPTION
The `java_home` variable is a derived value rather than a configurable value.