### PR TITLE
Fixed documentation on java_jdk_download_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ java_jdk_redis_mirror: '{{ java_mirror_base }}/{{ java_otn_jdk_path }}'
 
 ### The following only apply to Java versions prior to 9 ###
 
-# ID in JDK download URL (introduced in 8u121)
-java_jdk_download_id: ''
-
 # Timeout for JDK download response in seconds
 java_jce_download_timeout_seconds: 30
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,9 +44,6 @@ java_jdk_redis_mirror: '{{ java_mirror_base }}/{{ java_otn_jdk_path }}'
 
 ### The following only apply to Java versions prior to 9 ###
 
-# ID in JDK download URL (introduced in 8u121)
-java_jdk_download_id: ''
-
 # Timeout for JDK download response in seconds
 java_jce_download_timeout_seconds: 30
 


### PR DESCRIPTION
While it wasn't used for the initial version of Java 9 it was introduced for later versions.