### PR TITLE
Increased Fedora test version to 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Requirements
 
         * Fedora
 
-            * 25
+            * 27
 
     * SUSE Family
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
         - 7
     - name: Fedora
       versions:
-        - 25
+        - 27
     # Galaxy doesn't support version 42.2 yet: "Invalid platform: opensuse-42.2 (skipping)"
     # - name: opensuse
     #   versions:

--- a/molecule/fedora-java-min-online/molecule.yml
+++ b/molecule/fedora-java-min-online/molecule.yml
@@ -9,8 +9,8 @@ lint:
   name: yamllint
 
 platforms:
-  - name: ansible-role-java-fedora-25
-    image: fedora:25
+  - name: ansible-role-java-fedora
+    image: fedora:27
 
 provisioner:
   name: ansible


### PR DESCRIPTION
27 is the latest stable version of Fedora.