### PR TITLE
Do not sudo on local_action

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,7 @@
   local_action: stat path='{{ java_local_archive_dir }}/{{ java_jdk_redis_filename }}'
   register: local_JDK_file
   ignore_errors: yes
+  become: no
   when: java_use_local_archive
 
 - name: copy JDK from local box


### PR DESCRIPTION
* Prevents using `become` (sudo) when performing `local_action`.
* Prevents the following error, when calling a playbook like so:

```
localuser@localhost:~/projects/ansible$ ansible-playbook --become --ask-become-pass --user=remoteuser provision.yaml

... [ other output ] ...

TASK [gantsign.java : assert JCE version vars] ****************************************
skipping: [10.xx.xx.xx]

TASK [gantsign.java : assert Binary Code License accepted] ****************************
ok: [10.xx.xx.xx] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [gantsign.java : create download directory] **************************************
ok: [10.xx.xx.xx]

TASK [gantsign.java : check for JDK on local box] *************************************
fatal: [10.xx.xx.xx -> localhost]: FAILED! => {"changed": false, "module_stderr": "Sorry, try again.\n[sudo via ansible, key=gmcqrqtsglkdnmjmfmgoxbqmycfuohmu] password: \nsudo: 1 incorrect password attempt\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
...ignoring

TASK [gantsign.java : copy JDK from local box] ****************************************
fatal: [10.xx.xx.xx]: FAILED! => {"msg": "The conditional check 'java_use_local_archive and local_JDK_file.stat.exists' failed. The error was: error while evaluating conditional (java_use_local_archive and local_JDK_file.stat.exists): 'dict object' has no attribute 'stat'\n\nThe error appears to have been in '/home/localuser/projects/ansible/roles/gantsign.java/tasks/main.yml': line 59, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: copy JDK from local box\n  ^ here\n"}
        to retry, use: --limit @/home/localuser/projects/ansible/provision.retry
```