### PR TITLE
Resolved deprecation warning for include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,9 +132,10 @@
     group: root
     mode: 'go-w'
 
-- include: unlimited-jce.yml
+- import_tasks: unlimited-jce.yml
 
-- include: write-environment-config.yml
+- name: write environment config
+  include_tasks: write-environment-config.yml
   when: java_is_default_installation
 
 # Set Java facts

--- a/tasks/unlimited-jce.yml
+++ b/tasks/unlimited-jce.yml
@@ -1,5 +1,6 @@
 ---
-- include: install-unlimited-jce.yml
+- name: install unlimited JCE (Java < 9)
+  include_tasks: install-unlimited-jce.yml
   when: java_major_version | version_compare('9', '<')
 
 - name: enable unlimited strength JCE (Java 9)


### PR DESCRIPTION
Since Ansible 2.4 `include` has been deprecated.

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
```