### PR TITLE
Replaced filters with tests where possible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
     - '../vars/jce-versions/{{ java_major_version }}.yml'
     - ../vars/jce-versions/default.yml
   include_vars: '{{ item }}'
-  when: java_major_version | version_compare('9', '<')
+  when: java_major_version is version_compare('9', '<')
 
 - name: assert JDK version vars
   assert:
@@ -36,7 +36,7 @@
       - java_jce_redis_mirror not in (None, '')
       - java_jce_redis_filename not in (None, '')
       - java_jce_redis_folder not in (None, '')
-  when: java_major_version | version_compare('9', '<')
+  when: java_major_version is version_compare('9', '<')
 
 - name: assert Binary Code License accepted
   assert:

--- a/tasks/unlimited-jce.yml
+++ b/tasks/unlimited-jce.yml
@@ -1,7 +1,7 @@
 ---
 - name: install unlimited JCE (Java < 9)
   include_tasks: install-unlimited-jce.yml
-  when: java_major_version | version_compare('9', '<')
+  when: java_major_version is version_compare('9', '<')
 
 - name: enable unlimited strength JCE (Java 9)
   lineinfile:
@@ -9,4 +9,4 @@
     state: present
     regexp: '^crypto\.policy='
     line: 'crypto.policy=unlimited'
-  when: java_major_version | version_compare('9', '==')
+  when: java_major_version is version_compare('9', '==')


### PR DESCRIPTION
Using filter syntax is deprecated since Ansible 2.5.

```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|version_compare` use `result is version_compare`.
```