### PR TITLE
Simplified Docker Python library install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,75 +7,51 @@ matrix:
     - env:
         - MOLECULE_SCENARIO=ubuntu-min-java-min-online
         - ANSIBLE_VERSION=2.4.6
-        - DOCKER_LIB=docker-py
     - env:
         - MOLECULE_SCENARIO=ubuntu-min-java-max-online
         - ANSIBLE_VERSION=2.4.6
-        - DOCKER_LIB=docker-py
     - env:
         - MOLECULE_SCENARIO=ubuntu-max-java-min-offline
         - ANSIBLE_VERSION=2.6.1
-        # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-        - DOCKER_LIB='docker<3.0'
     - env:
         - MOLECULE_SCENARIO=ubuntu-max-java-max-offline
         - ANSIBLE_VERSION=2.6.1
-        # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-        - DOCKER_LIB='docker<3.0'
     - env:
         - MOLECULE_SCENARIO=debian-min-java-min-online
         - ANSIBLE_VERSION=2.4.6
-        - DOCKER_LIB=docker-py
     - env:
         - MOLECULE_SCENARIO=debian-min-java-max-online
         - ANSIBLE_VERSION=2.4.6
-        - DOCKER_LIB=docker-py
     - env:
         - MOLECULE_SCENARIO=debian-max-java-min-offline
         - ANSIBLE_VERSION=2.6.1
-        # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-        - DOCKER_LIB='docker<3.0'
     - env:
         - MOLECULE_SCENARIO=debian-max-java-max-offline
         - ANSIBLE_VERSION=2.6.1
-        # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-        - DOCKER_LIB='docker<3.0'
     - env:
         - MOLECULE_SCENARIO=centos-min-java-min-online
         - ANSIBLE_VERSION=2.4.6
-        - DOCKER_LIB=docker-py
     - env:
         - MOLECULE_SCENARIO=centos-min-java-max-online
         - ANSIBLE_VERSION=2.4.6
-        - DOCKER_LIB=docker-py
     - env:
         - MOLECULE_SCENARIO=centos-max-java-min-offline
         - ANSIBLE_VERSION=2.6.1
-        # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-        - DOCKER_LIB='docker<3.0'
     - env:
         - MOLECULE_SCENARIO=centos-max-java-max-offline
         - ANSIBLE_VERSION=2.6.1
-        # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-        - DOCKER_LIB='docker<3.0'
     - env:
         - MOLECULE_SCENARIO=fedora-java-min-online
         - ANSIBLE_VERSION=2.4.6
-        - DOCKER_LIB=docker-py
     - env:
         - MOLECULE_SCENARIO=opensuse-java-min-online
         - ANSIBLE_VERSION=2.4.6
-        - DOCKER_LIB=docker-py
     - env:
         - MOLECULE_SCENARIO=fedora-java-min-online
         - ANSIBLE_VERSION=2.6.1
-        # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-        - DOCKER_LIB='docker<3.0'
     - env:
         - MOLECULE_SCENARIO=opensuse-java-min-online
         - ANSIBLE_VERSION=2.6.1
-        # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-        - DOCKER_LIB='docker<3.0'
 
 # Require the standard build environment
 sudo: required
@@ -100,7 +76,7 @@ install:
   - pip install "ansible~=$ANSIBLE_VERSION"
 
   # Install Python API for Docker (required by Molecule Docker driver)
-  - pip install "$DOCKER_LIB"
+  - pip install docker
 
   # Install Molecule
   - pip install "molecule==2.16.0"


### PR DESCRIPTION
We can now use a common version for all Ansible versions.