### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/java-max/tests/test_role.py
+++ b/molecule/java-max/tests/test_role.py
@@ -8,8 +8,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_java(Command):
-    cmd = Command('. /etc/profile && java -version')
+def test_java(host):
+    cmd = host.run('. /etc/profile && java -version')
     assert cmd.rc == 0
     m = re.search('java version "([0-9]+)', cmd.stderr)
     assert m is not None
@@ -17,8 +17,8 @@ def test_java(Command):
     assert '10' == java_version
 
 
-def test_javac(Command):
-    cmd = Command('. /etc/profile && javac -version')
+def test_javac(host):
+    cmd = host.run('. /etc/profile && javac -version')
     assert cmd.rc == 0
     m = re.search('javac ([0-9]+)', cmd.stdout)
     assert m is not None
@@ -29,13 +29,13 @@ def test_javac(Command):
 @pytest.mark.parametrize('version_dir_pattern', [
     'jdk-10(\\.[0-9]+\\.[0-9]+)?$'
 ])
-def test_java_installed(Command, File, version_dir_pattern):
+def test_java_installed(host, version_dir_pattern):
 
-    java_home = Command.check_output('find %s | grep --color=never -E %s',
-                                     '/opt/java/',
-                                     version_dir_pattern)
+    java_home = host.check_output('find %s | grep --color=never -E %s',
+                                  '/opt/java/',
+                                  version_dir_pattern)
 
-    java_exe = File(java_home + '/bin/java')
+    java_exe = host.file(java_home + '/bin/java')
 
     assert java_exe.exists
     assert java_exe.is_file
@@ -47,8 +47,8 @@ def test_java_installed(Command, File, version_dir_pattern):
 @pytest.mark.parametrize('fact_group_name', [
     'java'
 ])
-def test_facts_installed(File, fact_group_name):
-    fact_file = File('/etc/ansible/facts.d/' + fact_group_name + '.fact')
+def test_facts_installed(host, fact_group_name):
+    fact_file = host.file('/etc/ansible/facts.d/' + fact_group_name + '.fact')
 
     assert fact_file.exists
     assert fact_file.is_file

--- a/molecule/java-min/tests/test_role.py
+++ b/molecule/java-min/tests/test_role.py
@@ -11,8 +11,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     'java',
     'javac'
 ])
-def test_java_tools(Command, command):
-    cmd = Command('. /etc/profile && ' + command + ' -version')
+def test_java_tools(host, command):
+    cmd = host.run('. /etc/profile && ' + command + ' -version')
     assert cmd.rc == 0
     assert ' 1.8.0_' in cmd.stderr
 
@@ -20,13 +20,13 @@ def test_java_tools(Command, command):
 @pytest.mark.parametrize('version_dir_pattern', [
     'jdk1\\.8\\.0_[0-9]+$'
 ])
-def test_java_installed(Command, File, version_dir_pattern):
+def test_java_installed(host, version_dir_pattern):
 
-    java_home = Command.check_output('find %s | grep --color=never -E %s',
-                                     '/opt/java/',
-                                     version_dir_pattern)
+    java_home = host.check_output('find %s | grep --color=never -E %s',
+                                  '/opt/java/',
+                                  version_dir_pattern)
 
-    java_exe = File(java_home + '/bin/java')
+    java_exe = host.file(java_home + '/bin/java')
 
     assert java_exe.exists
     assert java_exe.is_file
@@ -38,8 +38,8 @@ def test_java_installed(Command, File, version_dir_pattern):
 @pytest.mark.parametrize('fact_group_name', [
     'java'
 ])
-def test_facts_installed(File, fact_group_name):
-    fact_file = File('/etc/ansible/facts.d/' + fact_group_name + '.fact')
+def test_facts_installed(host, fact_group_name):
+    fact_file = host.file('/etc/ansible/facts.d/' + fact_group_name + '.fact')
 
     assert fact_file.exists
     assert fact_file.is_file


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.