### PR TITLE
Dropped support for Debian Wheezy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Wheezy (7)
             * Jessie (8)
             * Stretch (9)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,7 +26,6 @@ galaxy_info:
       versions:
         - stretch
         - jessie
-        - wheezy
   galaxy_tags:
     - java
     - jdk

--- a/molecule/debian-min-java-max-online/molecule.yml
+++ b/molecule/debian-min-java-max-online/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-java-debian-min-java-max
-    image: debian:7
+    image: debian:8
 
 provisioner:
   name: ansible

--- a/molecule/debian-min-java-min-online/molecule.yml
+++ b/molecule/debian-min-java-min-online/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-java-debian-min
-    image: debian:7
+    image: debian:8
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Debian ended support in May 2018.