### PR TITLE
Do not sudo on local_action

### DIFF
--- a/tasks/install-unlimited-jce.yml
+++ b/tasks/install-unlimited-jce.yml
@@ -3,6 +3,7 @@
   local_action: stat path='{{ java_local_archive_dir }}/{{ java_jce_redis_filename }}'
   register: local_JCE_file
   ignore_errors: yes
+  become: no
   when: java_use_local_archive
 
 - name: copy JCE from local box


### PR DESCRIPTION
* Prevents using `become` (sudo) when performing `local_action` for the JCE tasks
* Similar to #123 , but for JCE.
* Prevents the following error, when calling the JCE steps on a playbook like so:

```
TASK [gantsign.java : check for JCE on local box] ************************************************************************************
task path: /home/localuser/vmware/ansible/roles/gantsign.java/tasks/install-unlimited-jce.yml:2
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: localuser
<localhost> EXEC /bin/sh -c 'echo ~localuser && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/localuser/.ansible/tmp/ansible-tmp-1538030566.63-6117558826717 `" && echo ansible-tmp-1538030566.63-6117558826717="` echo /home/localuser/.ansible/tmp/ansible-tmp-1538030566.63-6117558826717 `" )&& sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible/modules/files/stat.py
<localhost> PUT /home/localuser/.ansible/tmp/ansible-local-8592Nbmq7S/tmpu4zU6E TO /home/localuser/.ansible/tmp/ansible-tmp-1538030566.63-6117558826717/stat.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/localuser/.ansible/tmp/ansible-tmp-1538030566.63-6117558826717/ /home/localuser/.ansible/tmp/ansible-tmp-1538030566.63-6117558826717/stat.py && sleep 0'
<localhost> EXEC /bin/sh -c 'sudo -H -S -n -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-zjbnoxekymoypclhfqftmjrkwucxuskx; /usr/bin/python2 /home/localuser/.ansible/tmp/ansible-tmp-1538030566.63-6117558826717/stat.py'"'"' && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /home/localuser/.ansible/tmp/ansible-tmp-1538030566.63-6117558826717/ > /dev/null 2>&1 && sleep 0'
fatal: [13.80.5.221 -> localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "/bin/sh: sudo: command not found\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 127
}
```
