### PR TITLE
Temporally disable Java 11 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,39 +11,39 @@ matrix:
     - env:
         - MOLECULE_SCENARIO=ubuntu-min-java-min-online
         - MOLECULEW_ANSIBLE=2.5.10
-    - env:
-        - MOLECULE_SCENARIO=ubuntu-min-java-max-online
-        - MOLECULEW_ANSIBLE=2.5.10
+    # - env:
+    #     - MOLECULE_SCENARIO=ubuntu-min-java-max-online
+    #     - MOLECULEW_ANSIBLE=2.5.10
     - env:
         - MOLECULE_SCENARIO=ubuntu-max-java-min-offline
         - MOLECULEW_ANSIBLE=2.7.0
-    - env:
-        - MOLECULE_SCENARIO=ubuntu-max-java-max-offline
-        - MOLECULEW_ANSIBLE=2.7.0
+    # - env:
+    #     - MOLECULE_SCENARIO=ubuntu-max-java-max-offline
+    #     - MOLECULEW_ANSIBLE=2.7.0
     - env:
         - MOLECULE_SCENARIO=debian-min-java-min-online
         - MOLECULEW_ANSIBLE=2.5.10
-    - env:
-        - MOLECULE_SCENARIO=debian-min-java-max-online
-        - MOLECULEW_ANSIBLE=2.5.10
+    # - env:
+    #     - MOLECULE_SCENARIO=debian-min-java-max-online
+    #     - MOLECULEW_ANSIBLE=2.5.10
     - env:
         - MOLECULE_SCENARIO=debian-max-java-min-offline
         - MOLECULEW_ANSIBLE=2.7.0
-    - env:
-        - MOLECULE_SCENARIO=debian-max-java-max-offline
-        - MOLECULEW_ANSIBLE=2.7.0
+    # - env:
+    #     - MOLECULE_SCENARIO=debian-max-java-max-offline
+    #     - MOLECULEW_ANSIBLE=2.7.0
     - env:
         - MOLECULE_SCENARIO=centos-min-java-min-online
         - MOLECULEW_ANSIBLE=2.5.10
-    - env:
-        - MOLECULE_SCENARIO=centos-min-java-max-online
-        - MOLECULEW_ANSIBLE=2.5.10
+    # - env:
+    #     - MOLECULE_SCENARIO=centos-min-java-max-online
+    #     - MOLECULEW_ANSIBLE=2.5.10
     - env:
         - MOLECULE_SCENARIO=centos-max-java-min-offline
         - MOLECULEW_ANSIBLE=2.7.0
-    - env:
-        - MOLECULE_SCENARIO=centos-max-java-max-offline
-        - MOLECULEW_ANSIBLE=2.7.0
+    # - env:
+    #     - MOLECULE_SCENARIO=centos-max-java-max-offline
+    #     - MOLECULEW_ANSIBLE=2.7.0
     - env:
         - MOLECULE_SCENARIO=fedora-java-min-online
         - MOLECULEW_ANSIBLE=2.5.10


### PR DESCRIPTION
Due to AdoptOpenJDK API bug.