### PR TITLE
Fixed support for OpenJ9 JDKs

### DIFF
--- a/molecule/java-max-offline/playbook.yml
+++ b/molecule/java-max-offline/playbook.yml
@@ -9,7 +9,7 @@
     - name: download JDK for offline install
       local_action: >
         get_url
-        url='https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release={{ 'jdk-11+28' | urlencode }}&type=jdk'
+        url='https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release={{ 'jdk-11+28' | urlencode }}&type=jdk&heap_size=normal'
         dest='{{ java_local_archive_dir }}/OpenJDK11-jdk_x64_linux_hotspot_11_28.tar.gz'
         force=no
         timeout='{{ java_jdk_download_timeout_seconds }}'

--- a/vars/adoptopenjdk/main.yml
+++ b/vars/adoptopenjdk/main.yml
@@ -6,4 +6,4 @@ java_release: "{{ (java_version in ('8', '9', '10', '11')) | ternary('latest', j
 java_full_version: '{{ java_version }}'
 
 # The URL for the AdoptOpenJDK API request
-java_api_request: 'https://api.adoptopenjdk.net/v2/info/releases/openjdk{{ java_major_version }}?openjdk_impl={{ java_implementation }}&os={{ java_os }}&arch={{ java_arch }}&release={{ java_release | urlencode }}&type=jdk'
+java_api_request: 'https://api.adoptopenjdk.net/v2/info/releases/openjdk{{ java_major_version }}?openjdk_impl={{ java_implementation }}&os={{ java_os }}&arch={{ java_arch }}&release={{ java_release | urlencode }}&type=jdk&heap_size={{ java_heap_size }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -22,3 +22,6 @@ java_os: linux
 
 # Architecture
 java_arch: x64
+
+# Heap size
+java_heap_size: normal


### PR DESCRIPTION
Failed if release had artifacts for more than one heap size.