### PR TITLE
OracleJDK_11 and OpenJDK improvements

### DIFF
--- a/tasks/adoptopenjdk-checksum.yml
+++ b/tasks/adoptopenjdk-checksum.yml
@@ -14,4 +14,4 @@
 
 - name: set JDK checksum var from file
   set_fact:
-    java_redis_sha256sum: "{{ java_checksum_file.content | b64decode | regex_replace('^([0-9a-f]+).*', '\\1') | trim }}"
+    java_redis_sha256sum_adoptopen: "{{ java_checksum_file.content | b64decode | regex_replace('^([0-9a-f]+).*', '\\1') | trim }}"

--- a/tasks/adoptopenjdk-query.yml
+++ b/tasks/adoptopenjdk-query.yml
@@ -20,7 +20,6 @@
 - name: set checksum URL var from API
   set_fact:
     java_redis_sha256sum_url: '{{ (java_api_response.json[0] | default(java_api_response.json)).binaries[0].checksum_link }}'
-  when: java_redis_sha256sum in (None, '', omit)
 
 - name: set JDK filename var from API
   set_fact:

--- a/tasks/adoptopenjdk.yml
+++ b/tasks/adoptopenjdk.yml
@@ -17,7 +17,7 @@
   include_tasks: adoptopenjdk-copy-local-jdk.yml
   when:
     - java_use_local_archive
-    - java_redis_sha256sum not in (None, '', omit)
+    - java_redis_sha256sum_adoptopen not in (None, '', omit)
     - java_redis_filename not in (None, '', omit)
 
 - name: check for JDK on remote box
@@ -33,7 +33,7 @@
   when: >
     java_release == 'latest'
     or java_redis_filename in (None, '', omit)
-    or java_redis_sha256sum in (None, '', omit)
+    or java_redis_sha256sum_adoptopen in (None, '', omit)
     or (java_redis_mirror in (None, '', omit) and not remote_JDK_file.stat.exists)
 
 - name: java version to install
@@ -46,7 +46,6 @@
 
 - name: fetch checksum
   include_tasks: adoptopenjdk-checksum.yml
-  when: java_redis_sha256sum in (None, '', omit)
 
 - name: check for JDK on remote box
   stat:
@@ -58,15 +57,15 @@
 - name: assert existing JDK matches checksum
   assert:
     that:
-      - remote_JDK_file.stat.checksum == java_redis_sha256sum
-    msg: 'Checksum failed: {{ remote_JDK_file.stat.checksum }} != {{ java_redis_sha256sum }}'
+      - remote_JDK_file.stat.checksum == java_redis_sha256sum_adoptopen
+    msg: 'Checksum failed: {{ remote_JDK_file.stat.checksum }} != {{ java_redis_sha256sum_adoptopen }}'
   when: remote_JDK_file.stat.exists
 
 - name: download JDK
   get_url:
     url: '{{ java_redis_url }}'
     dest: '{{ java_download_dir }}/{{ java_redis_filename }}'
-    sha256sum: '{{ java_redis_sha256sum }}'
+    sha256sum: '{{ java_redis_sha256sum_adoptopen }}'
     force: no
     timeout: '{{ java_download_timeout_seconds }}'
     mode: 'u=rw,go=r'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,8 +32,3 @@
 - name: re-read facts
   setup:
     filter: ansible_local
-
-- name: clear facts
-  set_fact:
-    java_redis_sha256sum:
-    java_redis_filename:

--- a/tasks/oracle.yml
+++ b/tasks/oracle.yml
@@ -2,7 +2,7 @@
 - name: assert JDK major version supported
   assert:
     that:
-      - java_major_version in ('7', '8', '9', '10')
+      - java_major_version in ('7', '8', '9', '10', '11')
 
 - name: load Oracle JDK vars
   include_vars: ../vars/oracle/main.yml
@@ -17,6 +17,18 @@
     - '../vars/oracle/jdk-versions/{{ java_major_version }}.yml'
     - ../vars/oracle/jdk-versions/default.yml
   include_vars: '{{ item }}'
+
+- name: Create java_full_version var
+  set_fact:
+    java_full_version: "{{ (java_version == '8') | ternary(java_default_java8_version, (java_version == '9') | ternary(java_default_java9_version, (java_version == '10') | ternary(java_default_java10_version, (java_version == '11') | ternary(java_default_java11_version, java_version)))) }}"
+
+- name: Create java_jdk_version var
+  set_fact:
+    java_jdk_version: "{{ java_full_version | regex_replace('^([0-9]+)[u\\+]([0-9]+)$', '1.\\1.0_\\2') }}"
+
+- name: Create java_vendor_home var
+  set_fact:
+    java_vendor_home: '{{ java_install_dir }}/jdk{{ java_jdk_version }}'
 
 - name: load JDK version vars
   with_first_found:
@@ -134,7 +146,9 @@
   become: yes
   unarchive:
     src: '{{ java_download_dir }}/{{ java_jdk_redis_filename }}'
-    dest: '{{ java_install_dir }}'
+    dest: '{{ java_home }}'
+    extra_opts:
+      - '--strip-components=1'
     creates: '{{ java_home }}/bin/java'
     copy: no
     owner: root

--- a/vars/adoptopenjdk/main.yml
+++ b/vars/adoptopenjdk/main.yml
@@ -7,3 +7,5 @@ java_full_version: '{{ java_version }}'
 
 # The URL for the AdoptOpenJDK API request
 java_api_request: 'https://api.adoptopenjdk.net/v2/info/releases/openjdk{{ java_major_version }}?openjdk_impl={{ java_implementation }}&os={{ java_os }}&arch={{ java_arch }}&release={{ java_release | urlencode }}&type=jdk&heap_size={{ java_heap_size }}'
+
+java_redis_sha256sum_adoptopen: None

--- a/vars/oracle/jdk-versions/11.0.1.yml
+++ b/vars/oracle/jdk-versions/11.0.1.yml
@@ -1,0 +1,10 @@
+---
+
+# SHA256 sum for the redistributable JDK package
+java_redis_sha256sum: 'e7fd856bacad04b6dbf3606094b6a81fa9930d6dbb044bbd787be7ea93abc885'
+
+# The build number for this JDK version
+java_version_build: '13'
+
+# ID in JDK download URL
+java_jdk_download_id: '90cf5d8f270a4347a95050320eef3fb7'

--- a/vars/oracle/jdk-versions/11.yml
+++ b/vars/oracle/jdk-versions/11.yml
@@ -1,0 +1,12 @@
+---
+# Path for JDK download within Oracle Technology Network
+java_otn_jdk_path: 'jdk/{{ java_full_version }}+{{ java_version_build }}/{{ java_jdk_download_id }}'
+
+# The root folder of this Java installation
+java_home: '{{ java_install_dir }}/oracle-jdk-{{ java_full_version }}'
+
+# Java JDK version number
+java_jdk_version: '{{ java_major_version }}'
+
+# File name for the JDK redistributable installation file
+java_jdk_redis_filename: 'jdk-{{ java_full_version }}_linux-x64_bin.tar.gz'

--- a/vars/oracle/main.yml
+++ b/vars/oracle/main.yml
@@ -8,11 +8,5 @@ java_default_java9_version: '9.0.4'
 # Default Java 10 version number
 java_default_java10_version: '10.0.2'
 
-# Java full version number
-java_full_version: "{{ (java_version == '8') | ternary(java_default_java8_version, (java_version == '9') | ternary(java_default_java9_version, (java_version == '10') | ternary(java_default_java10_version, java_version))) }}"
-
-# Java JDK version number
-java_jdk_version: "{{ java_full_version | regex_replace('^([0-9]+)[u\\+]([0-9]+)$', '1.\\1.0_\\2') }}"
-
-# The root folder of this Java installation
-java_vendor_home: '{{ java_install_dir }}/jdk{{ java_jdk_version }}'
+# Default Java 11 version number
+java_default_java11_version: '11.0.1'


### PR DESCRIPTION
    *Support Oracle 11.0.1

    *Make changes also in adoptopenjdk to be able
     to run the oracle role after it

    *Most changes are made because of variable precedence
     in Ansible and the way same variables (i.e. same name ) where
     declared in different context and different ways.
     Thus, when a variable is set with a -set_fact task then an
     include_vars with an assignment on the same variable will not
     overwrite it. See: https://docs.ansible.com/ansible/2.7/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable