### PR TITLE
Fixed AdoptOpenJDK support for Java 11

### DIFF
--- a/docs/AdoptOpenJDK.md
+++ b/docs/AdoptOpenJDK.md
@@ -40,5 +40,5 @@ bit more information (i.e. `java_redis_filename` and
     - role: gantsign.java
       java_version: 'jdk-11.0.1+13'
       java_redis_filename: 'OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz'
-      java_redis_sha256sum: '7e9904e1bfa197e6e72570207cb2bd63dd7cc4bf5f97bc5454c1fc5a559a8bf1'
+      java_redis_sha256sum: '22bd2f1a2e0cb6e4075967bfeda4a960b0325879305aa739a0ba2d6e5cd4c3e2'
 ```

--- a/molecule/java-max-offline/playbook.yml
+++ b/molecule/java-max-offline/playbook.yml
@@ -20,7 +20,7 @@
       java_use_local_archive: yes
       java_version: 'jdk-11.0.1+13'
       java_redis_filename: 'OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz'
-      java_redis_sha256sum: '7e9904e1bfa197e6e72570207cb2bd63dd7cc4bf5f97bc5454c1fc5a559a8bf1'
+      java_redis_sha256sum: '22bd2f1a2e0cb6e4075967bfeda4a960b0325879305aa739a0ba2d6e5cd4c3e2'
 
   post_tasks:
     - name: verify java facts

--- a/tasks/adoptopenjdk.yml
+++ b/tasks/adoptopenjdk.yml
@@ -101,7 +101,7 @@
   unarchive:
     src: '{{ java_download_dir }}/{{ java_redis_filename }}'
     extra_opts:
-      - '--strip-components=2'
+      - "--strip-components={{ (java_major_version in ('8', '9', '10')) | ternary('2', '1') }}"
     dest: '{{ java_home }}'
     creates: '{{ java_home }}/bin/java'
     copy: no


### PR DESCRIPTION
AdoptOpenJDK have changed the packaging for the Java 11 releases.