### PR TITLE
Removed unused test vars

### DIFF
--- a/molecule/centos-max-java-max-offline/molecule.yml
+++ b/molecule/centos-max-java-max-offline/molecule.yml
@@ -16,9 +16,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-max-offline/playbook.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
   lint:
     name: ansible-lint
 

--- a/molecule/centos-min-java-max-online/molecule.yml
+++ b/molecule/centos-min-java-max-online/molecule.yml
@@ -16,9 +16,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-max-online/playbook.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
   lint:
     name: ansible-lint
 

--- a/molecule/debian-max-java-max-offline/molecule.yml
+++ b/molecule/debian-max-java-max-offline/molecule.yml
@@ -16,9 +16,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-max-offline/playbook.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
   lint:
     name: ansible-lint
 

--- a/molecule/debian-min-java-max-online/molecule.yml
+++ b/molecule/debian-min-java-max-online/molecule.yml
@@ -16,9 +16,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-max-online/playbook.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
   lint:
     name: ansible-lint
 

--- a/molecule/ubuntu-max-java-max-offline/molecule.yml
+++ b/molecule/ubuntu-max-java-max-offline/molecule.yml
@@ -16,9 +16,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-max-offline/playbook.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
   lint:
     name: ansible-lint
 

--- a/molecule/ubuntu-min-java-max-online/molecule.yml
+++ b/molecule/ubuntu-min-java-max-online/molecule.yml
@@ -16,9 +16,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-max-online/playbook.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
   lint:
     name: ansible-lint
 


### PR DESCRIPTION
These were used for the Oracle JDK but now maximum Java version used for testing is using AdoptOpenJDK these are no longer needed.