### PR TITLE
Added CDS archive generation for AdoptOpenJDK 8-10

### DIFF
--- a/tasks/adoptopenjdk.yml
+++ b/tasks/adoptopenjdk.yml
@@ -127,4 +127,4 @@
   command: '{{ java_home }}/bin/java -Xshare:dump'
   args:
     creates: '{{ java_home }}/lib/server/classes.jsa'
-  when: java_major_version == '11' and java_implementation == 'hotspot'
+  when: java_major_version in ('8', '9', '10', '11') and java_implementation == 'hotspot'


### PR DESCRIPTION
CDS archive was already generated for Java 11