### PR TITLE
Added support for Java 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,12 @@ matrix:
     - env:
         - MOLECULE_SCENARIO=opensuse-java-min-online
         - MOLECULEW_ANSIBLE=2.7.0
+    - env:
+        - MOLECULE_SCENARIO=ubuntu-min-java-max-non-lts-online
+        - MOLECULEW_ANSIBLE=2.5.10
+    - env:
+        - MOLECULE_SCENARIO=ubuntu-max-java-max-non-lts-offline
+        - MOLECULEW_ANSIBLE=2.7.0
 
 # Require the standard build environment
 sudo: required

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ are shown below):
 
 ```yaml
 # Java version number
-# Specify '8', '9', '10' or '11' to get the latest patch version of that
+# Specify '8', '9', '10', '11' or '12' to get the latest patch version of that
 # release.
 java_version: 'jdk-11.0.2+9'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Java version number
-# Specify '8', '9', '10' or '11' to get the latest patch version of that
+# Specify '8', '9', '10', '11' or '12' to get the latest patch version of that
 # release.
 java_version: 'jdk-11.0.2+9'
 

--- a/docs/AdoptOpenJDK.md
+++ b/docs/AdoptOpenJDK.md
@@ -8,7 +8,7 @@ With [curl](https://curl.haxx.se) and [jq](https://stedolan.github.io/jq) you
 can view the available versions by running the following command:
 
 ```bash
-for ((i = 8; i <= 11; i++)) do (curl --silent http \
+for ((i = 8; i <= 12; i++)) do (curl --silent http \
   "https://api.adoptopenjdk.net/v2/info/releases/openjdk$i?openjdk_impl=hotspot" \
   | jq --raw-output '.[].release_name'); done
 ```

--- a/molecule/java-max-non-lts-offline/playbook.yml
+++ b/molecule/java-max-non-lts-offline/playbook.yml
@@ -1,0 +1,40 @@
+---
+- name: Converge
+  hosts: all
+
+  pre_tasks:
+    - name: create local archive directory
+      file:
+        state: directory
+        mode: 'u=rwx,go=rx'
+        dest: '{{ java_local_archive_dir }}'
+      delegate_to: localhost
+
+    - name: download JDK for offline install
+      get_url:
+        url: "https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=hotspot&os=linux&arch=x64&release={{ 'jdk-12+33' | urlencode }}&type=jdk&heap_size=normal"  # noqa 204
+        dest: '{{ java_local_archive_dir }}/OpenJDK12U-jdk_x64_linux_hotspot_12_33.tar.gz'
+        force: no
+        timeout: '{{ java_jdk_download_timeout_seconds }}'
+        mode: 'u=rw,go=r'
+      delegate_to: localhost
+
+  roles:
+    - role: ansible-role-java
+      java_use_local_archive: yes
+      java_version: 'jdk-12+33'
+      java_redis_filename: 'OpenJDK12U-jdk_x64_linux_hotspot_12_33.tar.gz'
+      java_redis_sha256sum: '4739064dc439a05487744cce0ba951cb544ed5e796f6c699646e16c09da5dd6a'
+
+  post_tasks:
+    - name: verify java facts
+      assert:
+        that:
+          - ansible_local.java.general.version is defined
+          - ansible_local.java.general.home is defined
+
+    - name: install find - required for tests (dnf)
+      dnf:
+        name: findutils
+        state: present
+      when: ansible_pkg_mgr == 'dnf'

--- a/molecule/java-max-non-lts-online/playbook.yml
+++ b/molecule/java-max-non-lts-online/playbook.yml
@@ -1,0 +1,21 @@
+---
+- name: Converge
+  hosts: all
+
+  roles:
+    - role: ansible-role-java
+      java_version: '12'
+      java_use_local_archive: no
+
+  post_tasks:
+    - name: verify java facts
+      assert:
+        that:
+          - ansible_local.java.general.version is defined
+          - ansible_local.java.general.home is defined
+
+    - name: install find - required for tests (dnf)
+      dnf:
+        name: findutils
+        state: present
+      when: ansible_pkg_mgr == 'dnf'

--- a/molecule/java-max-non-lts/tests/test_role.py
+++ b/molecule/java-max-non-lts/tests/test_role.py
@@ -1,0 +1,57 @@
+import os
+import pytest
+import re
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_java(host):
+    cmd = host.run('. /etc/profile && java -version')
+    assert cmd.rc == 0
+    m = re.search('(?:java|openjdk) version "([0-9]+)', cmd.stderr)
+    assert m is not None
+    java_version = m.group(1)
+    assert '12' == java_version
+
+
+def test_javac(host):
+    cmd = host.run('. /etc/profile && javac -version')
+    assert cmd.rc == 0
+    m = re.search('javac ([0-9]+)', cmd.stdout)
+    assert m is not None
+    java_version = m.group(1)
+    assert '12' == java_version
+
+
+@pytest.mark.parametrize('version_dir_pattern', [
+    'jdk-12(\\.[0-9]+\\.[0-9]+)?$'
+])
+def test_java_installed(host, version_dir_pattern):
+
+    java_home = host.check_output('find %s | grep --color=never -E %s',
+                                  '/opt/java/',
+                                  version_dir_pattern)
+
+    java_exe = host.file(java_home + '/bin/java')
+
+    assert java_exe.exists
+    assert java_exe.is_file
+    assert java_exe.user == 'root'
+    assert java_exe.group == 'root'
+    assert oct(java_exe.mode) == '0755'
+
+
+@pytest.mark.parametrize('fact_group_name', [
+    'java'
+])
+def test_facts_installed(host, fact_group_name):
+    fact_file = host.file('/etc/ansible/facts.d/' + fact_group_name + '.fact')
+
+    assert fact_file.exists
+    assert fact_file.is_file
+    assert fact_file.user == 'root'
+    assert fact_file.group == 'root'
+    assert oct(fact_file.mode) == '0644'

--- a/molecule/ubuntu-max-java-max-non-lts-offline/INSTALL.rst
+++ b/molecule/ubuntu-max-java-max-non-lts-offline/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/ubuntu-max-java-max-non-lts-offline/molecule.yml
+++ b/molecule/ubuntu-max-java-max-non-lts-offline/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-ubuntu-max-java-max-non-lts
+    image: ubuntu:18.04
+    dockerfile: ../default/Dockerfile.j2
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../java-max-non-lts-offline/playbook.yml
+  lint:
+    name: ansible-lint
+
+scenario:
+  name: ubuntu-max-java-max-non-lts-offline
+
+verifier:
+  name: testinfra
+  directory: ../java-max-non-lts/tests
+  lint:
+    name: flake8

--- a/molecule/ubuntu-min-java-max-non-lts-online/INSTALL.rst
+++ b/molecule/ubuntu-min-java-max-non-lts-online/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/ubuntu-min-java-max-non-lts-online/molecule.yml
+++ b/molecule/ubuntu-min-java-max-non-lts-online/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint:
+  name: yamllint
+
+platforms:
+  - name: ansible-role-java-ubuntu-min-java-max-non-lts
+    image: ubuntu:14.04
+    dockerfile: ../default/Dockerfile.j2
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../java-max-non-lts-online/playbook.yml
+  lint:
+    name: ansible-lint
+
+scenario:
+  name: ubuntu-min-java-max-non-lts-online
+
+verifier:
+  name: testinfra
+  directory: ../java-max-non-lts/tests
+  lint:
+    name: flake8

--- a/tasks/adoptopenjdk.yml
+++ b/tasks/adoptopenjdk.yml
@@ -2,7 +2,7 @@
 - name: assert JDK major version supported
   assert:
     that:
-      - java_major_version in ('8', '9', '10', '11')
+      - java_major_version in ('8', '9', '10', '11', '12')
 
 - name: load AdoptOpenJDK vars
   include_vars: ../vars/adoptopenjdk/main.yml

--- a/vars/adoptopenjdk/main.yml
+++ b/vars/adoptopenjdk/main.yml
@@ -1,6 +1,6 @@
 ---
 # Java AdoptOpenJDK release
-java_release: "{{ (java_version in ('8', '9', '10', '11')) | ternary('latest', java_version) }}"
+java_release: "{{ (java_version in ('8', '9', '10', '11', '12')) | ternary('latest', java_version) }}"
 
 # Java Full version number
 java_full_version: '{{ java_version }}'


### PR DESCRIPTION
The latest non-LTS release. Java 11 remains the default JDK.