### PR TITLE
Increased minimum Ansible version to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ matrix:
   include:
     - env:
         - MOLECULE_SCENARIO=ubuntu-min-java-min-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=ubuntu-min-java-max-lts-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=ubuntu-max-java-min-offline
         - MOLECULEW_ANSIBLE=2.9.1
@@ -22,10 +22,10 @@ matrix:
         - MOLECULEW_ANSIBLE=2.9.1
     - env:
         - MOLECULE_SCENARIO=debian-min-java-min-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=debian-min-java-max-lts-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=debian-max-java-min-offline
         - MOLECULEW_ANSIBLE=2.9.1
@@ -34,10 +34,10 @@ matrix:
         - MOLECULEW_ANSIBLE=2.9.1
     - env:
         - MOLECULE_SCENARIO=centos-min-java-min-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=centos-min-java-max-lts-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=centos-max-java-min-offline
         - MOLECULEW_ANSIBLE=2.9.1
@@ -46,10 +46,10 @@ matrix:
         - MOLECULEW_ANSIBLE=2.9.1
     - env:
         - MOLECULE_SCENARIO=fedora-java-min-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=opensuse-java-min-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=fedora-java-min-online
         - MOLECULEW_ANSIBLE=2.9.1
@@ -58,7 +58,7 @@ matrix:
         - MOLECULEW_ANSIBLE=2.9.1
     - env:
         - MOLECULE_SCENARIO=ubuntu-min-java-max-non-lts-online
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
     - env:
         - MOLECULE_SCENARIO=ubuntu-max-java-max-non-lts-offline
         - MOLECULEW_ANSIBLE=2.9.1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ versions. Due to this, support for Java 7 has been discontinued.
 Requirements
 ------------
 
-* Ansible >= 2.6
+* Ansible >= 2.7
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing the Java JDK.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.6
+  min_ansible_version: 2.7
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.7.