### PR TITLE
Dropped support for Ubuntu Trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Requirements
 
         * Ubuntu
 
-            * Trusty (14.04)
             * Xenial (16.04)
             * Bionic (18.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,7 +18,6 @@ galaxy_info:
         - 15.1
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
     - name: Debian

--- a/molecule/ubuntu-min-java-max-lts-online/molecule.yml
+++ b/molecule/ubuntu-min-java-max-lts-online/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-java-ubuntu-min-java-max-lts
-    image: ubuntu:14.04
+    image: ubuntu:16.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:

--- a/molecule/ubuntu-min-java-max-non-lts-online/molecule.yml
+++ b/molecule/ubuntu-min-java-max-non-lts-online/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-java-ubuntu-min-java-max-non-lts
-    image: ubuntu:14.04
+    image: ubuntu:16.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:

--- a/molecule/ubuntu-min-java-min-online/molecule.yml
+++ b/molecule/ubuntu-min-java-min-online/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-java-ubuntu-min
-    image: ubuntu:14.04
+    image: ubuntu:16.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Trusty (14.04).