### PR TITLE
Added support for Java 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ are shown below):
 
 ```yaml
 # Java version number
-# Specify '8', '9', '10', '11', '12' or '13' to get the latest patch version of
-# that release.
+# Specify '8', '9', '10', '11', '12', '13' or '14' to get the latest patch
+# version of that release.
 java_version: 'jdk-11.0.6+10'
 
 # Base installation directory for any Java distribution
@@ -134,7 +134,7 @@ You can install a specific version of the JDK by specifying the `java_version`.
 running the following command:
 
 ```bash
-for ((i = 8; i <= 13; i++)) do (curl --silent http \
+for ((i = 8; i <= 14; i++)) do (curl --silent http \
   "https://api.adoptopenjdk.net/v2/info/releases/openjdk$i?openjdk_impl=hotspot" \
   | jq --raw-output '.[].release_name'); done
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Java version number
-# Specify '8', '9', '10', '11', '12' or '13' to get the latest patch version of
-# that release.
+# Specify '8', '9', '10', '11', '12', '13' or '14' to get the latest patch
+# version of that release.
 java_version: 'jdk-11.0.6+10'
 
 # Base installation directory for any Java distribution

--- a/molecule/java-max-non-lts-offline/playbook.yml
+++ b/molecule/java-max-non-lts-offline/playbook.yml
@@ -12,8 +12,8 @@
 
     - name: download JDK for offline install
       get_url:
-        url: "https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl=hotspot&os=linux&arch=x64&release={{ 'jdk-13+33' | urlencode }}&type=jdk&heap_size=normal"  # noqa 204
-        dest: '{{ java_local_archive_dir }}/OpenJDK13U-jdk_x64_linux_hotspot_13_33.tar.gz'
+        url: "https://api.adoptopenjdk.net/v2/binary/releases/openjdk14?openjdk_impl=hotspot&os=linux&arch=x64&release={{ 'jdk-14+36' | urlencode }}&type=jdk&heap_size=normal"  # noqa 204
+        dest: '{{ java_local_archive_dir }}/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz'
         force: no
         timeout: '{{ java_download_timeout_seconds }}'
         mode: 'u=rw,go=r'
@@ -22,9 +22,9 @@
   roles:
     - role: ansible-role-java
       java_use_local_archive: yes
-      java_version: 'jdk-13+33'
-      java_redis_filename: 'OpenJDK13U-jdk_x64_linux_hotspot_13_33.tar.gz'
-      java_redis_sha256sum: 'e562caeffa89c834a69a44242d802eae3523875e427f07c05b1902c152638368'
+      java_version: 'jdk-14+36'
+      java_redis_filename: 'OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz'
+      java_redis_sha256sum: '6c06853332585ab58834d9e8a02774b388e6e062ef6c4084b4f058c67f2e81b5'
 
   post_tasks:
     - name: verify java facts

--- a/molecule/java-max-non-lts-online/playbook.yml
+++ b/molecule/java-max-non-lts-online/playbook.yml
@@ -4,7 +4,7 @@
 
   roles:
     - role: ansible-role-java
-      java_version: '13'
+      java_version: '14'
       java_use_local_archive: no
 
   post_tasks:

--- a/molecule/java-max-non-lts/tests/test_role.py
+++ b/molecule/java-max-non-lts/tests/test_role.py
@@ -14,7 +14,7 @@ def test_java(host):
     m = re.search('(?:java|openjdk) version "([0-9]+)', cmd.stderr)
     assert m is not None
     java_version = m.group(1)
-    assert '13' == java_version
+    assert '14' == java_version
 
 
 def test_javac(host):
@@ -23,11 +23,11 @@ def test_javac(host):
     m = re.search('javac ([0-9]+)', cmd.stdout)
     assert m is not None
     java_version = m.group(1)
-    assert '13' == java_version
+    assert '14' == java_version
 
 
 @pytest.mark.parametrize('version_dir_pattern', [
-    'jdk-13(\\.[0-9]+\\.[0-9]+)?$'
+    'jdk-14(\\.[0-9]+\\.[0-9]+)?$'
 ])
 def test_java_installed(host, version_dir_pattern):
 

--- a/tasks/adoptopenjdk.yml
+++ b/tasks/adoptopenjdk.yml
@@ -2,7 +2,7 @@
 - name: assert JDK major version supported
   assert:
     that:
-      - java_major_version in ('8', '9', '10', '11', '12', '13')
+      - java_major_version in ('8', '9', '10', '11', '12', '13', '14')
 
 - name: create download directory
   file:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 java_major_version: "{{ java_version | regex_replace('^(?:jdk-?)?([0-9]+).*', '\\1') }}"
 
 # Java AdoptOpenJDK release
-java_release: "{{ (java_version in ('8', '9', '10', '11', '12', '13')) | ternary('latest', java_version) }}"
+java_release: "{{ (java_version in ('8', '9', '10', '11', '12', '13', '14')) | ternary('latest', java_version) }}"
 
 # Java Full version number
 java_full_version: '{{ java_version }}'


### PR DESCRIPTION
The latest non-LTS release. Java 11 remains the default JDK.