### PR TITLE
Removed sudo key from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,6 @@ matrix:
         - MOLECULE_SCENARIO=ubuntu-max-java-max-non-lts-offline
         - MOLECULEW_ANSIBLE=2.9.1
 
-# Require the standard build environment
-sudo: required
-
 # Require Ubuntu 16.04
 dist: xenial
 


### PR DESCRIPTION
The key `sudo` has no effect anymore.