### PR TITLE
Updated Travis CI config to use jobs key instead of matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - MOLECULEW_USE_SYSTEM=true
 
-matrix:
+jobs:
   include:
     - env:
         - MOLECULE_SCENARIO=ubuntu-min-java-min-online


### PR DESCRIPTION
`jobs` is the new preferred name.