### PR TITLE
Fixed installing multiple JDK versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,3 +32,5 @@
   set_fact:
     java_redis_sha256sum:
     java_redis_filename:
+    java_major_version:
+    java_release_name:


### PR DESCRIPTION
Regression due to AdoptOpenJDK v3 API change.

Fix: resolves #226