### PR TITLE
Added support for Java 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ are shown below):
 
 ```yaml
 # Java version number
-# Specify '8', '9', '10', '11', '12', '13' or '14' to get the latest patch
+# Specify '8', '9', '10', '11', '12', '13', '14' or '15' to get the latest patch
 # version of that release.
 java_version: '11.0.8+10'
 
@@ -135,7 +135,7 @@ You can install a specific version of the JDK by specifying the `java_version`.
 running the following command:
 
 ```bash
-for ((i = 8; i <= 14; i++)) do (curl --silent http \
+for ((i = 8; i <= 15; i++)) do (curl --silent http \
   "https://api.adoptopenjdk.net/v3/assets/feature_releases/$i/ga?\
 architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&\
 os=linux&project=jdk&sort_order=DESC&vendor=adoptopenjdk" \

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Java version number
-# Specify '8', '9', '10', '11', '12', '13' or '14' to get the latest patch
+# Specify '8', '9', '10', '11', '12', '13', '14' or '15' to get the latest patch
 # version of that release.
 java_version: '11.0.8+10'
 

--- a/molecule/java-max-non-lts-offline/playbook.yml
+++ b/molecule/java-max-non-lts-offline/playbook.yml
@@ -12,8 +12,8 @@
 
     - name: download JDK for offline install
       get_url:
-        url: "https://api.adoptopenjdk.net/v3/binary/version/{{ 'jdk-14+36' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk"  # noqa 204
-        dest: '{{ java_local_archive_dir }}/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz'
+        url: "https://api.adoptopenjdk.net/v3/binary/version/{{ 'jdk-15+36' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk"  # noqa 204
+        dest: '{{ java_local_archive_dir }}/OpenJDK15U-jdk_x64_linux_hotspot_15_36.tar.gz'
         force: no
         timeout: '{{ java_download_timeout_seconds }}'
         mode: 'u=rw,go=r'
@@ -22,11 +22,11 @@
   roles:
     - role: ansible-role-java
       java_use_local_archive: yes
-      java_major_version: '14'
-      java_version: '14.0.0+36.1'
-      java_release_name: 'jdk-14+36'
-      java_redis_filename: 'OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz'
-      java_redis_sha256sum: '6c06853332585ab58834d9e8a02774b388e6e062ef6c4084b4f058c67f2e81b5'
+      java_major_version: '15'
+      java_version: '15.0.0+36'
+      java_release_name: 'jdk-15+36'
+      java_redis_filename: 'OpenJDK15U-jdk_x64_linux_hotspot_15_36.tar.gz'
+      java_redis_sha256sum: 'c198593d1b5188ee3570e2ca33c3bc004aaefbda2c11e68e58ae7296cf5c3982'
 
   post_tasks:
     - name: verify java facts

--- a/molecule/java-max-non-lts-online/playbook.yml
+++ b/molecule/java-max-non-lts-online/playbook.yml
@@ -4,7 +4,7 @@
 
   roles:
     - role: ansible-role-java
-      java_version: '14'
+      java_version: '15'
       java_use_local_archive: no
 
   post_tasks:

--- a/molecule/java-max-non-lts/tests/test_role.py
+++ b/molecule/java-max-non-lts/tests/test_role.py
@@ -14,7 +14,7 @@ def test_java(host):
     m = re.search('(?:java|openjdk) version "([0-9]+)', cmd.stderr)
     assert m is not None
     java_version = m.group(1)
-    assert '14' == java_version
+    assert '15' == java_version
 
 
 def test_javac(host):
@@ -23,11 +23,11 @@ def test_javac(host):
     m = re.search('javac ([0-9]+)', cmd.stdout)
     assert m is not None
     java_version = m.group(1)
-    assert '14' == java_version
+    assert '15' == java_version
 
 
 @pytest.mark.parametrize('version_dir_pattern', [
-    'jdk-14(\\.[0-9]+\\.[0-9]+)?(\\+[0-9]+)?$'
+    'jdk-15(\\.[0-9]+\\.[0-9]+)?(\\+[0-9]+)?$'
 ])
 def test_java_installed(host, version_dir_pattern):
 


### PR DESCRIPTION
The latest non-LTS release. Java 11 remains the default JDK.