### PR TITLE
Drop support for CentOS 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Dependency versions
         run: ./moleculew wrapper-versions
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Molecule test
         run: ./moleculew test --scenario-name=${{ matrix.molecule-scenario }}
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Requirements
 
         * CentOS
 
-            * 6
             * 7
 
         * Fedora

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 6
         - 7
     - name: Fedora
       versions:

--- a/molecule/centos-min-java-max-lts-online/molecule.yml
+++ b/molecule/centos-min-java-max-lts-online/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-java-centos-min-java-max-lts
-    image: centos:6
+    image: centos:7
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:

--- a/molecule/centos-min-java-min-online/molecule.yml
+++ b/molecule/centos-min-java-min-online/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-java-centos-min
-    image: centos:6
+    image: centos:7
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
RedHat ended CentOS 6 support on 2020-11-30.