### PR TITLE
Updated tests for Java 16

### DIFF
--- a/molecule/java-max-non-lts-offline/converge.yml
+++ b/molecule/java-max-non-lts-offline/converge.yml
@@ -18,8 +18,8 @@
 
     - name: download JDK for offline install
       get_url:
-        url: "https://api.adoptopenjdk.net/v3/binary/version/{{ 'jdk-15+36' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk"  # noqa 204
-        dest: '{{ java_local_archive_dir }}/OpenJDK15U-jdk_x64_linux_hotspot_15_36.tar.gz'
+        url: "https://api.adoptopenjdk.net/v3/binary/version/{{ 'jdk-16+36' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk"  # noqa 204
+        dest: '{{ java_local_archive_dir }}/OpenJDK16U-jdk_x64_linux_hotspot_16_36.tar.gz'
         force: no
         timeout: '{{ java_download_timeout_seconds }}'
         mode: 'u=rw,go=r'
@@ -28,11 +28,11 @@
   roles:
     - role: ansible-role-java
       java_use_local_archive: yes
-      java_major_version: '15'
-      java_version: '15.0.0+36'
-      java_release_name: 'jdk-15+36'
-      java_redis_filename: 'OpenJDK15U-jdk_x64_linux_hotspot_15_36.tar.gz'
-      java_redis_sha256sum: 'c198593d1b5188ee3570e2ca33c3bc004aaefbda2c11e68e58ae7296cf5c3982'
+      java_major_version: '16'
+      java_version: '16.0.0+36'
+      java_release_name: 'jdk-16+36'
+      java_redis_filename: 'OpenJDK16U-jdk_x64_linux_hotspot_16_36.tar.gz'
+      java_redis_sha256sum: '2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'
 
   post_tasks:
     - name: verify java facts

--- a/molecule/java-max-non-lts-online/converge.yml
+++ b/molecule/java-max-non-lts-online/converge.yml
@@ -11,7 +11,7 @@
 
   roles:
     - role: ansible-role-java
-      java_version: '15'
+      java_version: '16'
       java_use_local_archive: no
 
   post_tasks:

--- a/molecule/java-max-non-lts/tests/test_role.py
+++ b/molecule/java-max-non-lts/tests/test_role.py
@@ -8,7 +8,7 @@ def test_java(host):
     m = re.search('(?:java|openjdk) version "([0-9]+)', cmd.stderr)
     assert m is not None
     java_version = m.group(1)
-    assert '15' == java_version
+    assert '16' == java_version
 
 
 def test_javac(host):
@@ -17,11 +17,11 @@ def test_javac(host):
     m = re.search('javac ([0-9]+)', cmd.stdout)
     assert m is not None
     java_version = m.group(1)
-    assert '15' == java_version
+    assert '16' == java_version
 
 
 @pytest.mark.parametrize('version_dir_pattern', [
-    'jdk-15(\\.[0-9]+\\.[0-9]+)?(\\+[0-9]+)?$'
+    'jdk-16(\\.[0-9]+\\.[0-9]+)?(\\+[0-9]+)?$'
 ])
 def test_java_installed(host, version_dir_pattern):
 


### PR DESCRIPTION
The latest non-LTS release. Java 11 remains the default JDK.