### PR TITLE
Updated tests and docs for Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ are shown below):
 
 ```yaml
 # Java version number
-# Specify '8', '9', '10', '11', '12', '13', '14' or '15' to get the latest patch
-# version of that release.
+# Specify '8', '9', '10', '11', '12', '13', '14', '15', '16' or '17' to get the
+# latest patch version of that release.
 java_version: '11.0.12+7'
 
 # Base installation directory for any Java distribution
@@ -135,7 +135,7 @@ You can install a specific version of the JDK by specifying the `java_version`.
 running the following command:
 
 ```bash
-for ((i = 8; i <= 15; i++)) do (curl --silent http \
+for ((i = 8; i <= 17; i++)) do (curl --silent http \
   "https://api.adoptopenjdk.net/v3/assets/feature_releases/$i/ga?\
 architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&\
 os=linux&project=jdk&sort_order=DESC&vendor=adoptopenjdk" \

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Java version number
-# Specify '8', '9', '10', '11', '12', '13', '14' or '15' to get the latest patch
-# version of that release.
+# Specify '8', '9', '10', '11', '12', '13', '14', '15', '16' or '17' to get the
+# latest patch version of that release.
 java_version: '11.0.12+7'
 
 # Base installation directory for any Java distribution

--- a/molecule/java-max-non-lts-offline/converge.yml
+++ b/molecule/java-max-non-lts-offline/converge.yml
@@ -18,8 +18,8 @@
 
     - name: download JDK for offline install
       get_url:
-        url: "https://api.adoptopenjdk.net/v3/binary/version/{{ 'jdk-16+36' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk"  # noqa 204
-        dest: '{{ java_local_archive_dir }}/OpenJDK16U-jdk_x64_linux_hotspot_16_36.tar.gz'
+        url: "https://api.adoptopenjdk.net/v3/binary/version/{{ 'jdk-17+35' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk"  # noqa 204
+        dest: '{{ java_local_archive_dir }}/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz'
         force: no
         timeout: '{{ java_download_timeout_seconds }}'
         mode: 'u=rw,go=r'
@@ -28,11 +28,11 @@
   roles:
     - role: ansible-role-java
       java_use_local_archive: yes
-      java_major_version: '16'
-      java_version: '16.0.0+36'
-      java_release_name: 'jdk-16+36'
-      java_redis_filename: 'OpenJDK16U-jdk_x64_linux_hotspot_16_36.tar.gz'
-      java_redis_sha256sum: '2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'
+      java_major_version: '17'
+      java_version: '17.0.0+35'
+      java_release_name: 'jdk-17+35'
+      java_redis_filename: 'OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz'
+      java_redis_sha256sum: '6f1335d9a7855159f982dac557420397be9aa85f3f7bc84e111d25871c02c0c7'
 
   post_tasks:
     - name: verify java facts

--- a/molecule/java-max-non-lts-online/converge.yml
+++ b/molecule/java-max-non-lts-online/converge.yml
@@ -11,7 +11,7 @@
 
   roles:
     - role: ansible-role-java
-      java_version: '16'
+      java_version: '17'
       java_use_local_archive: no
 
   post_tasks:

--- a/molecule/java-max-non-lts/tests/test_role.py
+++ b/molecule/java-max-non-lts/tests/test_role.py
@@ -8,7 +8,7 @@ def test_java(host):
     m = re.search('(?:java|openjdk) version "([0-9]+)', cmd.stderr)
     assert m is not None
     java_version = m.group(1)
-    assert '16' == java_version
+    assert '17' == java_version
 
 
 def test_javac(host):
@@ -17,11 +17,11 @@ def test_javac(host):
     m = re.search('javac ([0-9]+)', cmd.stdout)
     assert m is not None
     java_version = m.group(1)
-    assert '16' == java_version
+    assert '17' == java_version
 
 
 @pytest.mark.parametrize('version_dir_pattern', [
-    'jdk-16(\\.[0-9]+\\.[0-9]+)?(\\+[0-9]+)?$'
+    'jdk-17(\\.[0-9]+\\.[0-9]+)?(\\+[0-9]+)?$'
 ])
 def test_java_installed(host, version_dir_pattern):
 


### PR DESCRIPTION
Java 11 remains the default JDK.