### PR TITLE
Dropped support for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Requirements
 
         * Debian
 
-            * Jessie (8)
             * Stretch (9)
             * Buster (10)
             * Bullseye (11)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,7 +23,6 @@ galaxy_info:
     - name: Debian
       versions:
         - stretch
-        - jessie
         - buster
         - bullseye
   galaxy_tags:

--- a/molecule/debian-min-java-max-lts-online/molecule.yml
+++ b/molecule/debian-min-java-max-lts-online/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-java-debian-min-java-max-lts
-    image: debian:8
+    image: debian:9
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:

--- a/molecule/debian-min-java-min-online/molecule.yml
+++ b/molecule/debian-min-java-min-online/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-java-debian-min
-    image: debian:8
+    image: debian:9
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Debian ended LTS support in June 2020.