### PR TITLE
Added support for Eclipse Adoptium

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ are shown below):
 # release.
 java_version: '11.0.12+7'
 
+# The Java vendor
+# Must be either 'adoptopenjdk' or 'adoptium'.
+# Note: while the default is currently adoptopenjdk, this will change to
+# adoptium at a later point and adoptopenjdk will be removed when the service is
+# discontinued.
+java_vendor: adoptopenjdk
+
 # Base installation directory for any Java distribution
 java_install_dir: '/opt/java'
 
@@ -100,12 +107,14 @@ java_redis_mirror:
 java_redis_filename:
 
 # OpenJDK Implementation (hotspot, openj9)
+# Note: support for openj9 is deprecated. Openj9 is not available from Eclipse
+# Adoptium.
 java_implementation: hotspot
 
 # Timeout for JDK download response in seconds
 java_download_timeout_seconds: 600
 
-# The timeout for the AdoptOpenJDK API
+# The timeout for the AdoptOpenJDK/Adoptium API
 java_api_timeout_seconds: 30
 ```
 
@@ -132,13 +141,25 @@ You can install a specific version of the JDK by specifying the `java_version`.
 
 **Note:** with [curl](https://curl.haxx.se) and
 [jq](https://stedolan.github.io/jq) you can view the available versions by
-running the following command:
+running the following commands:
+
+**AdoptOpenJDK**
 
 ```bash
 for i in 8 11 16 17; do (curl --silent http \
   "https://api.adoptopenjdk.net/v3/assets/feature_releases/$i/ga?\
 architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&\
 os=linux&project=jdk&sort_order=DESC&vendor=adoptopenjdk" \
+   | jq --raw-output '.[].version_data.semver'); done
+```
+
+**Eclipse Adoptium**
+
+```bash
+for i in 8 11 16 17; do (curl --silent http \
+  "https://api.adoptium.net/v3/assets/feature_releases/$i/ga?\
+architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&\
+os=linux&project=jdk&sort_order=DESC&vendor=adoptium" \
    | jq --raw-output '.[].version_data.semver'); done
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,13 @@
 # release.
 java_version: '11.0.12+7'
 
+# The Java vendor
+# Must be either 'adoptopenjdk' or 'adoptium'.
+# Note: while the default is currently adoptopenjdk, this will change to
+# adoptium at a later point and adoptopenjdk will be removed when the service is
+# discontinued.
+java_vendor: adoptopenjdk
+
 # Base installation directory for any Java distribution
 java_install_dir: '/opt/java'
 
@@ -42,6 +49,8 @@ java_redis_mirror:
 java_redis_filename:
 
 # OpenJDK Implementation (hotspot, openj9)
+# Note: support for openj9 is deprecated. Openj9 is not available from Eclipse
+# Adoptium.
 java_implementation: hotspot
 
 # Timeout for JDK download response in seconds

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,6 +28,7 @@ galaxy_info:
     - java
     - jdk
     - adoptopenjdk
+    - adoptium
     - development
     - web
     - system

--- a/molecule/java-max-non-lts-online/converge.yml
+++ b/molecule/java-max-non-lts-online/converge.yml
@@ -12,6 +12,7 @@
   roles:
     - role: ansible-role-java
       java_version: '17'
+      java_vendor: 'adoptium'
       java_use_local_archive: no
 
   post_tasks:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,12 +1,15 @@
 ---
-# Java AdoptOpenJDK release
+# Java AdoptOpenJDK/Adoptium release
 java_release: "{{ java_version | string | regex_search('^((?:[0-9]+\\.)*)([0-9]+)$') | ternary('[' + (java_version | string) + ',' + (java_version | string | regex_replace('^((?:[0-9]+\\.)*)([0-9]+)$', '\\1')) + (((java_version | string | regex_replace('^((?:[0-9]+\\.)*)([0-9]+)$', '\\2') | int) + 1) | string) + ')', java_version) }}"
 
 # The root folder of this Java installation
 java_home: '{{ java_install_dir }}/{{ java_release_name }}'
 
-# The URL for the AdoptOpenJDK API request
-java_api_request: 'https://api.adoptopenjdk.net/v3/assets/version/{{ java_release | urlencode }}?jvm_impl={{ java_implementation }}&os={{ java_os }}&architecture={{ java_arch }}&heap_size={{ java_heap_size }}&image_type=jdk&project=jdk&release_type=ga&sort_order=DESC&vendor=adoptopenjdk'
+# The server for the AdoptOpenJDK/Adoptium API requests
+java_api_server: "{{ (java_vendor == 'adoptium') | ternary('https://api.adoptium.net', 'https://api.adoptopenjdk.net') }}"
+
+# The URL for the AdoptOpenJDK/Adoptium API requests
+java_api_request: "{{ java_api_server }}/v3/assets/version/{{ java_release | urlencode }}?jvm_impl={{ java_implementation }}&os={{ java_os }}&architecture={{ java_arch }}&heap_size={{ java_heap_size }}&image_type=jdk&project=jdk&release_type=ga&sort_order=DESC&vendor={{ (java_vendor == 'adoptium') | ternary('adoptium', 'adoptopenjdk') }}"
 
 # Operating System
 java_os: linux


### PR DESCRIPTION
AdoptOpenJDK remains the default for now.