### PR TITLE
Changed to use Eclipse Adoptium by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ Ansible Role: Java
 
 Role to install the Java JDK.
 
-**Important:** since the 9.0.0 release of this role the version numbers used
-have changed to use the semantic version from the AdoptOpenJDK v3 API. The
-fields required for offline install have also changed as have the install
-directories.
-
 Requirements
 ------------
 
@@ -63,11 +58,10 @@ are shown below):
 java_version: '11.0.14+9'
 
 # The Java vendor
-# Must be either 'adoptopenjdk' or 'adoptium'.
-# Note: while the default is currently adoptopenjdk, this will change to
-# adoptium at a later point and adoptopenjdk will be removed when the service is
-# discontinued.
-java_vendor: adoptopenjdk
+# Must be either 'adoptium' or 'adoptopenjdk'.
+# Note: the default is now 'adoptium', support for adoptopenjdk will be removed
+# when the service is discontinued.
+java_vendor: adoptium
 
 # Base installation directory for any Java distribution
 java_install_dir: '/opt/java'
@@ -114,7 +108,7 @@ java_implementation: hotspot
 # Timeout for JDK download response in seconds
 java_download_timeout_seconds: 600
 
-# The timeout for the AdoptOpenJDK/Adoptium API
+# The timeout for the Adoptium/AdoptOpenJDK API
 java_api_timeout_seconds: 30
 ```
 
@@ -143,16 +137,6 @@ You can install a specific version of the JDK by specifying the `java_version`.
 [jq](https://stedolan.github.io/jq) you can view the available versions by
 running the following commands:
 
-**AdoptOpenJDK**
-
-```bash
-for i in 8 11 16 17; do (curl --silent http \
-  "https://api.adoptopenjdk.net/v3/assets/feature_releases/$i/ga?\
-architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&\
-os=linux&project=jdk&sort_order=DESC&vendor=adoptopenjdk" \
-   | jq --raw-output '.[].version_data.semver'); done
-```
-
 **Eclipse Adoptium**
 
 ```bash
@@ -160,6 +144,16 @@ for i in 8 11 16 17; do (curl --silent http \
   "https://api.adoptium.net/v3/assets/feature_releases/$i/ga?\
 architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&\
 os=linux&project=jdk&sort_order=DESC&vendor=adoptium" \
+   | jq --raw-output '.[].version_data.semver'); done
+```
+
+**AdoptOpenJDK**
+
+```bash
+for i in 8 11 16 17; do (curl --silent http \
+  "https://api.adoptopenjdk.net/v3/assets/feature_releases/$i/ga?\
+architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&\
+os=linux&project=jdk&sort_order=DESC&vendor=adoptopenjdk" \
    | jq --raw-output '.[].version_data.semver'); done
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,11 +5,10 @@
 java_version: '11.0.14+9'
 
 # The Java vendor
-# Must be either 'adoptopenjdk' or 'adoptium'.
-# Note: while the default is currently adoptopenjdk, this will change to
-# adoptium at a later point and adoptopenjdk will be removed when the service is
-# discontinued.
-java_vendor: adoptopenjdk
+# Must be either 'adoptium' or 'adoptopenjdk'.
+# Note: the default is now 'adoptium', support for adoptopenjdk will be removed
+# when the service is discontinued.
+java_vendor: adoptium
 
 # Base installation directory for any Java distribution
 java_install_dir: '/opt/java'
@@ -56,5 +55,5 @@ java_implementation: hotspot
 # Timeout for JDK download response in seconds
 java_download_timeout_seconds: 600
 
-# The timeout for the AdoptOpenJDK API
+# The timeout for the Adoptium/AdoptOpenJDK API
 java_api_timeout_seconds: 30

--- a/molecule/java-max-non-lts-online/converge.yml
+++ b/molecule/java-max-non-lts-online/converge.yml
@@ -12,7 +12,6 @@
   roles:
     - role: ansible-role-java
       java_version: '17'
-      java_vendor: 'adoptium'
       java_use_local_archive: no
 
   post_tasks:

--- a/molecule/java-min-online/converge.yml
+++ b/molecule/java-min-online/converge.yml
@@ -12,6 +12,7 @@
   roles:
     - role: ansible-role-java
       java_version: 8.0.322+6
+      java_vendor: adoptopenjdk
       java_use_local_archive: no
 
   post_tasks:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,15 +1,15 @@
 ---
-# Java AdoptOpenJDK/Adoptium release
+# Java Adoptium/AdoptOpenJDK release
 java_release: "{{ java_version | string | regex_search('^((?:[0-9]+\\.)*)([0-9]+)$') | ternary('[' + (java_version | string) + ',' + (java_version | string | regex_replace('^((?:[0-9]+\\.)*)([0-9]+)$', '\\1')) + (((java_version | string | regex_replace('^((?:[0-9]+\\.)*)([0-9]+)$', '\\2') | int) + 1) | string) + ')', java_version) }}"
 
 # The root folder of this Java installation
 java_home: '{{ java_install_dir }}/{{ java_release_name }}'
 
-# The server for the AdoptOpenJDK/Adoptium API requests
-java_api_server: "{{ (java_vendor == 'adoptium') | ternary('https://api.adoptium.net', 'https://api.adoptopenjdk.net') }}"
+# The server for the Adoptium/AdoptOpenJDK API requests
+java_api_server: "{{ (java_vendor == 'adoptopenjdk') | ternary('https://api.adoptopenjdk.net', 'https://api.adoptium.net') }}"
 
-# The URL for the AdoptOpenJDK/Adoptium API requests
-java_api_request: "{{ java_api_server }}/v3/assets/version/{{ java_release | urlencode }}?jvm_impl={{ java_implementation }}&os={{ java_os }}&architecture={{ java_arch }}&heap_size={{ java_heap_size }}&image_type=jdk&project=jdk&release_type=ga&sort_order=DESC&vendor={{ (java_vendor == 'adoptium') | ternary('adoptium', 'adoptopenjdk') }}"
+# The URL for the Adoptium/AdoptOpenJDK API requests
+java_api_request: "{{ java_api_server }}/v3/assets/version/{{ java_release | urlencode }}?jvm_impl={{ java_implementation }}&os={{ java_os }}&architecture={{ java_arch }}&heap_size={{ java_heap_size }}&image_type=jdk&project=jdk&release_type=ga&sort_order=DESC&vendor={{ (java_vendor == 'adoptopenjdk') | ternary('adoptopenjdk', 'adoptium') }}"
 
 # Operating System
 java_os: linux


### PR DESCRIPTION
Support for AdoptOpenJDK will be removed once the service is discontinued.