### PR TITLE
Removed references to Oracle Binary Code License

### DIFF
--- a/molecule/debian-max-java-min-offline/molecule.yml
+++ b/molecule/debian-max-java-min-offline/molecule.yml
@@ -19,9 +19,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-min-offline/converge.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
 verifier:
   name: testinfra

--- a/molecule/debian-min-java-min-online/molecule.yml
+++ b/molecule/debian-min-java-min-online/molecule.yml
@@ -19,9 +19,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-min-online/converge.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
 verifier:
   name: testinfra

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,9 +3,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-min-online/converge.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
 dependency:
   name: galaxy

--- a/molecule/fedora-java-min-online/molecule.yml
+++ b/molecule/fedora-java-min-online/molecule.yml
@@ -19,9 +19,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-min-online/converge.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
 verifier:
   name: testinfra

--- a/molecule/opensuse-java-min-online/molecule.yml
+++ b/molecule/opensuse-java-min-online/molecule.yml
@@ -19,9 +19,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-min-online/converge.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
 verifier:
   name: testinfra

--- a/molecule/rocky-java-min-offline/molecule.yml
+++ b/molecule/rocky-java-min-offline/molecule.yml
@@ -19,9 +19,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-min-offline/converge.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
 verifier:
   name: testinfra

--- a/molecule/ubuntu-max-java-min-offline/molecule.yml
+++ b/molecule/ubuntu-max-java-min-offline/molecule.yml
@@ -19,9 +19,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-min-offline/converge.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
 verifier:
   name: testinfra

--- a/molecule/ubuntu-min-java-min-online/molecule.yml
+++ b/molecule/ubuntu-min-java-min-online/molecule.yml
@@ -19,9 +19,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../java-min-online/converge.yml
-  options:
-    extra-vars:
-      java_license_declaration: 'I accept the "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX" under the terms at http://www.oracle.com/technetwork/java/javase/terms/license/index.html'
 
 verifier:
   name: testinfra


### PR DESCRIPTION
We've not used the Oracle JDK in some time.