### PR TITLE
Upgraded minimum Ansible test version to 2.9.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - fedora-java-min-online
           - opensuse-java-min-online
         include:
-          - ansible-version: '2.9.1'
+          - ansible-version: '2.9.26'
             molecule-scenario: ubuntu-min-java-min-online
 
     env:


### PR DESCRIPTION
For Python 3.8 compatibility.