### PR TITLE
Added support for Java 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ are shown below):
 
 ```yaml
 # Java version number
-# Specify '8', '11', '16' or '17' to get the latest patch version of that
+# Specify '8', '11', '17' or '18' to get the latest patch version of that
 # release.
 java_version: '17.0.3+7'
 
@@ -132,7 +132,7 @@ You can install a specific version of the JDK by specifying the `java_version`.
 running the following command:
 
 ```bash
-for i in 8 11 16 17; do (curl --silent http \
+for i in 8 11 17 18; do (curl --silent http \
   "https://api.adoptium.net/v3/assets/feature_releases/$i/ga?\
 architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&\
 os=linux&project=jdk&sort_order=DESC&vendor=adoptium" \

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Java version number
-# Specify '8', '11', '16' or '17' to get the latest patch version of that
+# Specify '8', '11', '17' or '18' to get the latest patch version of that
 # release.
 java_version: '17.0.3+7'
 

--- a/molecule/java-max-non-lts-offline/converge.yml
+++ b/molecule/java-max-non-lts-offline/converge.yml
@@ -18,8 +18,8 @@
 
     - name: download JDK for offline install
       get_url:
-        url: "https://api.adoptium.net/v3/binary/version/{{ 'jdk-17.0.3+7' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptium?project=jdk"  # noqa 204
-        dest: '{{ java_local_archive_dir }}/OpenJDK17-jdk_x64_linux_hotspot_17.0.3_7.tar.gz'
+        url: "https://api.adoptium.net/v3/binary/version/{{ 'jdk-18.0.1+10' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptium?project=jdk"  # noqa 204
+        dest: '{{ java_local_archive_dir }}/OpenJDK17-jdk_x64_linux_hotspot_18.0.1_10.tar.gz'
         force: no
         timeout: '{{ java_download_timeout_seconds }}'
         mode: 'u=rw,go=r'
@@ -28,11 +28,11 @@
   roles:
     - role: ansible-role-java
       java_use_local_archive: yes
-      java_major_version: '17'
-      java_version: '17.0.3+7'
-      java_release_name: 'jdk-17.0.3+7'
-      java_redis_filename: 'OpenJDK17-jdk_x64_linux_hotspot_17.0.3_7.tar.gz'
-      java_redis_sha256sum: '81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73'
+      java_major_version: '18'
+      java_version: '18.0.1+10'
+      java_release_name: 'jdk-18.0.1+10'
+      java_redis_filename: 'OpenJDK17-jdk_x64_linux_hotspot_18.0.1_10.tar.gz'
+      java_redis_sha256sum: '16b1d9d75f22c157af04a1fd9c664324c7f4b5163c022b382a2f2e8897c1b0a2'
 
   post_tasks:
     - name: verify java facts

--- a/molecule/java-max-non-lts-online/converge.yml
+++ b/molecule/java-max-non-lts-online/converge.yml
@@ -11,7 +11,7 @@
 
   roles:
     - role: ansible-role-java
-      java_version: '17'
+      java_version: '18'
       java_use_local_archive: no
 
   post_tasks:


### PR DESCRIPTION
The latest non-LTS release. Java 17 remains the default JDK.