### PR TITLE
Dropped support for Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Stretch (9)
             * Buster (10)
             * Bullseye (11)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,7 +22,6 @@ galaxy_info:
         - jammy
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   galaxy_tags:

--- a/molecule/debian-min-java-max-lts-online/molecule.yml
+++ b/molecule/debian-min-java-max-lts-online/molecule.yml
@@ -15,7 +15,7 @@ lint: |
 
 platforms:
   - name: ansible-role-java-debian-min-java-max-lts
-    image: arm64v8/debian:9
+    image: arm64v8/debian:10
 
 provisioner:
   name: ansible

--- a/molecule/debian-min-java-min-online/molecule.yml
+++ b/molecule/debian-min-java-min-online/molecule.yml
@@ -15,7 +15,7 @@ lint: |
 
 platforms:
   - name: ansible-role-java-debian-min
-    image: arm64v8/debian:9
+    image: arm64v8/debian:10
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Debian standard support ended on 01 Jul 2022.