### PR TITLE
Fixed Molecule test dependencies

### DIFF
--- a/requirements/ansible-max.txt
+++ b/requirements/ansible-max.txt
@@ -561,10 +561,11 @@ tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via pytest
-urllib3==2.0.4 \
-    --hash=sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11 \
-    --hash=sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4
+urllib3==1.26.16 \
+    --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
+    --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
     # via
+    #   -r ./molecule.in
     #   docker
     #   requests
 websocket-client==1.6.1 \

--- a/requirements/ansible-min.txt
+++ b/requirements/ansible-min.txt
@@ -560,10 +560,11 @@ tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via pytest
-urllib3==2.0.4 \
-    --hash=sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11 \
-    --hash=sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4
+urllib3==1.26.16 \
+    --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
+    --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
     # via
+    #   -r ./molecule.in
     #   docker
     #   requests
 websocket-client==1.6.1 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -189,8 +189,9 @@ tomli==2.0.1
     #   tox
 tox==4.5.1
     # via -r tox.in
-urllib3==2.0.4
+urllib3==1.26.16
     # via
+    #   -r molecule.in
     #   docker
     #   requests
 virtualenv==20.24.2

--- a/requirements/molecule.in
+++ b/requirements/molecule.in
@@ -1,3 +1,5 @@
 ansible-compat<4
 molecule[docker]==4.0.4
 testinfra==5.3.1
+# TODO: Remove; Fix https://github.com/docker/docker-py/issues/3113
+urllib3<2

--- a/requirements/molecule.txt
+++ b/requirements/molecule.txt
@@ -563,10 +563,11 @@ tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via pytest
-urllib3==2.0.4 \
-    --hash=sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11 \
-    --hash=sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4
+urllib3==1.26.16 \
+    --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
+    --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
     # via
+    #   -r ./molecule.in
     #   docker
     #   requests
 websocket-client==1.6.1 \


### PR DESCRIPTION
The Python docker library is incompatible with urllib3 >= 2.