### PR TITLE
Updated Galaxy link to GansSign roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ More Roles From GantSign
 ------------------------
 
 You can find more roles from GantSign on
-[Ansible Galaxy](https://galaxy.ansible.com/gantsign).
+[Ansible Galaxy](https://galaxy.ansible.com/ui/standalone/namespaces/2463/).
 
 Development & Testing
 ---------------------


### PR DESCRIPTION
Broken by Galaxy NG.