### PR TITLE
Changed openSUSE tests to use Tumbleweed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requirements
 
         * openSUSE
 
-            * 15.4
+            * Tumbleweed
 
     * Note: other versions are likely to work but have not been tested.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
         - '35'
     - name: opensuse
       versions:
-        - '15.4'
+        - 'all'
     - name: Ubuntu
       versions:
         - focal

--- a/molecule/opensuse-java-min-online/molecule.yml
+++ b/molecule/opensuse-java-min-online/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-java-opensuse
-    image: opensuse/leap:15.4
+    image: opensuse/tumbleweed
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Leap defaults to Python 3.6, which is too old for recent Ansible versions.