### PR TITLE
Increased upper Debian test version to Bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Requirements
 
             * Buster (10)
             * Bullseye (11)
+            * Bookworm (12)
 
         * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - buster
         - bullseye
+        - bookworm
   galaxy_tags:
     - java
     - jdk

--- a/molecule/debian-max-java-max-lts-offline/molecule.yml
+++ b/molecule/debian-max-java-max-lts-offline/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-java-debian-max-java-max-lts
-    image: debian:11
+    image: debian:12
 
 provisioner:
   name: ansible

--- a/molecule/debian-max-java-min-offline/molecule.yml
+++ b/molecule/debian-max-java-min-offline/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-java-debian-max
-    image: debian:11
+    image: debian:12
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Bookworm is the latest stable version of Debian.