### PR TITLE
Added support for Java 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ are shown below):
 
 ```yaml
 # Java version number
-# Specify '8', '11', '17', '21' or '23' to get the latest patch version of that
+# Specify '8', '11', '17', '21' or '24' to get the latest patch version of that
 # release.
 java_version: '21.0.6+7'
 
@@ -126,7 +126,7 @@ You can install a specific version of the JDK by specifying the `java_version`.
 running the following command:
 
 ```bash
-for i in 23 21 17 11 8; do (curl --silent http \
+for i in 24 21 17 11 8; do (curl --silent http \
   "https://api.adoptium.net/v3/info/release_names?version=%5B$i,$(($i + 1)))\
 &release_type=ga" | jq --raw-output '.releases[]' | sed -E 's/^jdk\-?//'); done
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # code: language=ansible
 ---
 # Java version number
-# Specify '8', '11', '17', '21' or '23' to get the latest patch version of that
+# Specify '8', '11', '17', '21' or '24' to get the latest patch version of that
 # release.
 java_version: '21.0.6+7'
 

--- a/molecule/java-max-non-lts-offline/converge.yml
+++ b/molecule/java-max-non-lts-offline/converge.yml
@@ -26,8 +26,8 @@
 
     - name: Download JDK for offline install
       ansible.builtin.get_url:
-        url: "https://api.adoptium.net/v3/binary/version/{{ 'jdk-23.0.1+11' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptium?project=jdk"  # noqa 204
-        dest: '{{ java_local_archive_dir }}/OpenJDK23-jdk_x64_linux_hotspot_23.0.1_11.tar.gz'
+        url: "https://api.adoptium.net/v3/binary/version/{{ 'jdk-24+36' | urlencode }}/linux/x64/jdk/hotspot/normal/adoptium?project=jdk"  # noqa 204
+        dest: '{{ java_local_archive_dir }}/OpenJDK23-jdk_x64_linux_hotspot_24_36.tar.gz'
         force: false
         timeout: '{{ java_download_timeout_seconds }}'
         mode: 'u=rw,go=r'
@@ -36,11 +36,11 @@
   roles:
     - role: ansible-role-java
       java_use_local_archive: true
-      java_major_version: '23'
-      java_version: '23.0.1+11'
-      java_release_name: 'jdk-23.0.1+11'
-      java_redis_filename: 'OpenJDK23-jdk_x64_linux_hotspot_23.0.1_11.tar.gz'
-      java_redis_sha256sum: '2400267e4e9c0f6ae880a4d763af6caf18c673714bdee5debf8388b0b5d52886'
+      java_major_version: '24'
+      java_version: '24+36'
+      java_release_name: 'jdk-24+36'
+      java_redis_filename: 'OpenJDK23-jdk_x64_linux_hotspot_24_36.tar.gz'
+      java_redis_sha256sum: 'c340dee97b6aa215d248bc196dcac5b56e7be9b5c5d45e691344d40d5d0b171d'
 
   post_tasks:
     - name: Verify java facts

--- a/molecule/java-max-non-lts-online/converge.yml
+++ b/molecule/java-max-non-lts-online/converge.yml
@@ -19,7 +19,7 @@
 
   roles:
     - role: ansible-role-java
-      java_version: '23'
+      java_version: '24'
       java_use_local_archive: false
 
   post_tasks:

--- a/molecule/java-max-non-lts/tests/test_role.py
+++ b/molecule/java-max-non-lts/tests/test_role.py
@@ -8,7 +8,7 @@ def test_java(host):
     m = re.search('(?:java|openjdk) version "([0-9]+)', cmd.stderr)
     assert m is not None
     java_version = m.group(1)
-    assert '23' == java_version
+    assert '24' == java_version
 
 
 def test_javac(host):
@@ -17,11 +17,11 @@ def test_javac(host):
     m = re.search('javac ([0-9]+)', cmd.stdout)
     assert m is not None
     java_version = m.group(1)
-    assert '23' == java_version
+    assert '24' == java_version
 
 
 @pytest.mark.parametrize('version_dir_pattern', [
-    'jdk-23(\\.[0-9]+\\.[0-9]+)?(\\+[0-9]+)?$'
+    'jdk-24(\\.[0-9]+\\.[0-9]+)?(\\+[0-9]+)?$'
 ])
 def test_java_installed(host, version_dir_pattern):
 


### PR DESCRIPTION
The latest non-LTS release. Java 21 remains the default JDK.